### PR TITLE
Add Visual Studio build support + Fixes for 32bit build/C++ linkage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ run-test
 *.so
 compile_commands.json
 /.cache/
+/.vs/
+*.user

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ which makes use of this library must ask the user to provide a ROM for asset ext
 - To run the test program you'll need a SM64 US ROM in the root of the repository with the name `baserom.us.z64`.
 
 ## Building on Windows (test program not supported)
+
+### Visual Studio 2019
+- Ensure v142 x86/x64 build tools are installed.
+- Open .sln in Visual Studio 2019 and change whether to build in Debug/Release, and whether to build for 32bit or 64bit.
+
+### MinGW
 - [Follow steps 1-4 for setting up MSYS2 MinGW 64 here](https://github.com/sm64-port/sm64-port#windows), but replace the repository URL with `https://github.com/libsm64/libsm64.git`
 - Run `make` to build
 

--- a/libsm64.sln
+++ b/libsm64.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30011.22
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libsm64", "libsm64.vcxproj", "{5229697C-1DCD-4A12-8985-1D20B8A77AC9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5229697C-1DCD-4A12-8985-1D20B8A77AC9}.Debug|x64.ActiveCfg = Debug|x64
+		{5229697C-1DCD-4A12-8985-1D20B8A77AC9}.Debug|x64.Build.0 = Debug|x64
+		{5229697C-1DCD-4A12-8985-1D20B8A77AC9}.Debug|x86.ActiveCfg = Debug|Win32
+		{5229697C-1DCD-4A12-8985-1D20B8A77AC9}.Debug|x86.Build.0 = Debug|Win32
+		{5229697C-1DCD-4A12-8985-1D20B8A77AC9}.Release|x64.ActiveCfg = Release|x64
+		{5229697C-1DCD-4A12-8985-1D20B8A77AC9}.Release|x64.Build.0 = Release|x64
+		{5229697C-1DCD-4A12-8985-1D20B8A77AC9}.Release|x86.ActiveCfg = Release|Win32
+		{5229697C-1DCD-4A12-8985-1D20B8A77AC9}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D1DE41C9-561E-4DA8-B94A-E3D373AC78B3}
+	EndGlobalSection
+EndGlobal

--- a/libsm64.vcxproj
+++ b/libsm64.vcxproj
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{5229697C-1DCD-4A12-8985-1D20B8A77AC9}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>libsm64</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>src\external;$(IncludePath)</IncludePath>
+    <IntDir>$(SolutionDir)\build\</IntDir>
+    <OutDir>$(SolutionDir)\dist\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>src\external;$(IncludePath)</IncludePath>
+    <IntDir>$(SolutionDir)\build\</IntDir>
+    <OutDir>$(SolutionDir)\dist\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(IncludePath)</IncludePath>
+    <IntDir>$(SolutionDir)\build\</IntDir>
+    <OutDir>$(SolutionDir)\dist\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(IncludePath)</IncludePath>
+    <IntDir>$(SolutionDir)\build\</IntDir>
+    <OutDir>$(SolutionDir)\dist\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;SM64_LIB_EXPORT;_CRT_NONSTDC_NO_DEPRECATE;_USE_MATH_DEFINES</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <ExceptionHandling>false</ExceptionHandling>
+      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
+      <CompileAs>CompileAsC</CompileAs>
+      <DisableSpecificWarnings>4018;4244;4267;4305;4101;4068;6001;6308</DisableSpecificWarnings>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;SM64_LIB_EXPORT;_CRT_NONSTDC_NO_DEPRECATE;_USE_MATH_DEFINES</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <CompileAs>CompileAsC</CompileAs>
+      <DisableSpecificWarnings>4018;4244;4267;4305;4101;4068;6001;6308</DisableSpecificWarnings>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <ExceptionHandling>false</ExceptionHandling>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <FloatingPointModel>Fast</FloatingPointModel>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;SM64_LIB_EXPORT;_CRT_NONSTDC_NO_DEPRECATE;_USE_MATH_DEFINES</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <CompileAs>CompileAsC</CompileAs>
+      <DisableSpecificWarnings>4018;4244;4267;4305;4101;4068;6001;6308</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <ExceptionHandling>false</ExceptionHandling>
+      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS;SM64_LIB_EXPORT;_CRT_NONSTDC_NO_DEPRECATE;_USE_MATH_DEFINES</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <ExceptionHandling>false</ExceptionHandling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <CompileAs>CompileAsC</CompileAs>
+      <DisableSpecificWarnings>4018;4244;4267;4305;4101;4068;6001;6308</DisableSpecificWarnings>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="src\debug_print.h" />
+    <ClInclude Include="src\decomp\engine\geo_layout.h" />
+    <ClInclude Include="src\decomp\engine\graph_node.h" />
+    <ClInclude Include="src\decomp\engine\guMtxF2L.h" />
+    <ClInclude Include="src\decomp\engine\math_util.h" />
+    <ClInclude Include="src\decomp\engine\surface_collision.h" />
+    <ClInclude Include="src\decomp\game\area.h" />
+    <ClInclude Include="src\decomp\game\behavior_actions.h" />
+    <ClInclude Include="src\decomp\game\camera.h" />
+    <ClInclude Include="src\decomp\game\interaction.h" />
+    <ClInclude Include="src\decomp\game\level_update.h" />
+    <ClInclude Include="src\decomp\game\mario.h" />
+    <ClInclude Include="src\decomp\game\mario_actions_airborne.h" />
+    <ClInclude Include="src\decomp\game\mario_actions_automatic.h" />
+    <ClInclude Include="src\decomp\game\mario_actions_cutscene.h" />
+    <ClInclude Include="src\decomp\game\mario_actions_moving.h" />
+    <ClInclude Include="src\decomp\game\mario_actions_object.h" />
+    <ClInclude Include="src\decomp\game\mario_actions_stationary.h" />
+    <ClInclude Include="src\decomp\game\mario_actions_submerged.h" />
+    <ClInclude Include="src\decomp\game\mario_misc.h" />
+    <ClInclude Include="src\decomp\game\mario_step.h" />
+    <ClInclude Include="src\decomp\game\object_stuff.h" />
+    <ClInclude Include="src\decomp\game\platform_displacement.h" />
+    <ClInclude Include="src\decomp\game\rendering_graph_node.h" />
+    <ClInclude Include="src\decomp\game\save_file.h" />
+    <ClInclude Include="src\decomp\global_state.h" />
+    <ClInclude Include="src\decomp\include\audio_defines.h" />
+    <ClInclude Include="src\decomp\include\command_macros_base.h" />
+    <ClInclude Include="src\decomp\include\geo_commands.h" />
+    <ClInclude Include="src\decomp\include\level_misc_macros.h" />
+    <ClInclude Include="src\decomp\include\macros.h" />
+    <ClInclude Include="src\decomp\include\mario_animation_ids.h" />
+    <ClInclude Include="src\decomp\include\mario_geo_switch_case_ids.h" />
+    <ClInclude Include="src\decomp\include\object_fields.h" />
+    <ClInclude Include="src\decomp\include\platform_info.h" />
+    <ClInclude Include="src\decomp\include\PR\gbi.h" />
+    <ClInclude Include="src\decomp\include\PR\os_cont.h" />
+    <ClInclude Include="src\decomp\include\PR\ultratypes.h" />
+    <ClInclude Include="src\decomp\include\seq_ids.h" />
+    <ClInclude Include="src\decomp\include\sm64.h" />
+    <ClInclude Include="src\decomp\include\special_preset_names.h" />
+    <ClInclude Include="src\decomp\include\surface_terrains.h" />
+    <ClInclude Include="src\decomp\include\types.h" />
+    <ClInclude Include="src\decomp\mario\geo.inc.h" />
+    <ClInclude Include="src\decomp\mario\model.inc.h" />
+    <ClInclude Include="src\decomp\memory.h" />
+    <ClInclude Include="src\decomp\shim.h" />
+    <ClInclude Include="src\decomp\tools\libmio0.h" />
+    <ClInclude Include="src\decomp\tools\n64graphics.h" />
+    <ClInclude Include="src\decomp\tools\stb\stb_image.h" />
+    <ClInclude Include="src\decomp\tools\stb\stb_image_write.h" />
+    <ClInclude Include="src\decomp\tools\utils.h" />
+    <ClInclude Include="src\gfx_adapter.h" />
+    <ClInclude Include="src\gfx_adapter_commands.h" />
+    <ClInclude Include="src\gfx_macros.h" />
+    <ClInclude Include="src\libsm64.h" />
+    <ClInclude Include="src\load_anim_data.h" />
+    <ClInclude Include="src\load_surfaces.h" />
+    <ClInclude Include="src\load_tex_data.h" />
+    <ClInclude Include="src\obj_pool.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\debug_print.c" />
+    <ClCompile Include="src\decomp\engine\geo_layout.c" />
+    <ClCompile Include="src\decomp\engine\graph_node.c" />
+    <ClCompile Include="src\decomp\engine\graph_node_manager.c" />
+    <ClCompile Include="src\decomp\engine\guMtxF2L.c" />
+    <ClCompile Include="src\decomp\engine\math_util.c" />
+    <ClCompile Include="src\decomp\engine\surface_collision.c" />
+    <ClCompile Include="src\decomp\game\behavior_actions.c" />
+    <ClCompile Include="src\decomp\game\interaction.c" />
+    <ClCompile Include="src\decomp\game\mario.c" />
+    <ClCompile Include="src\decomp\game\mario_actions_airborne.c" />
+    <ClCompile Include="src\decomp\game\mario_actions_automatic.c" />
+    <ClCompile Include="src\decomp\game\mario_actions_cutscene.c" />
+    <ClCompile Include="src\decomp\game\mario_actions_moving.c" />
+    <ClCompile Include="src\decomp\game\mario_actions_object.c" />
+    <ClCompile Include="src\decomp\game\mario_actions_stationary.c" />
+    <ClCompile Include="src\decomp\game\mario_actions_submerged.c" />
+    <ClCompile Include="src\decomp\game\mario_misc.c" />
+    <ClCompile Include="src\decomp\game\mario_step.c" />
+    <ClCompile Include="src\decomp\game\object_stuff.c" />
+    <ClCompile Include="src\decomp\game\platform_displacement.c" />
+    <ClCompile Include="src\decomp\game\rendering_graph_node.c" />
+    <ClCompile Include="src\decomp\global_state.c" />
+    <ClCompile Include="src\decomp\mario\geo.inc.c" />
+    <ClCompile Include="src\decomp\mario\model.inc.c" />
+    <ClCompile Include="src\decomp\memory.c" />
+    <ClCompile Include="src\decomp\tools\libmio0.c" />
+    <ClCompile Include="src\decomp\tools\n64graphics.c" />
+    <ClCompile Include="src\decomp\tools\utils.c" />
+    <ClCompile Include="src\gfx_adapter.c" />
+    <ClCompile Include="src\libsm64.c" />
+    <ClCompile Include="src\load_anim_data.c" />
+    <ClCompile Include="src\load_surfaces.c" />
+    <ClCompile Include="src\load_tex_data.c" />
+    <ClCompile Include="src\obj_pool.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/libsm64.vcxproj.filters
+++ b/libsm64.vcxproj.filters
@@ -1,0 +1,330 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\decomp">
+      <UniqueIdentifier>{fad62bcc-4df0-43ad-94a8-47cd33665d89}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\decomp\engine">
+      <UniqueIdentifier>{90a5affa-1187-4b7b-84fa-bb90544501e4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\decomp\game">
+      <UniqueIdentifier>{e89d8a2c-8c60-45ed-bd4c-1dd90da4d3d5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\decomp\include">
+      <UniqueIdentifier>{8f2fb049-32c1-42b0-861f-21669a4a09f5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\decomp\mario">
+      <UniqueIdentifier>{63298c95-fd35-4135-8f05-6ca5d5e449d5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\decomp\tools">
+      <UniqueIdentifier>{9dc2f078-75b7-4689-9507-47cf2307fcfd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\decomp\include\PR">
+      <UniqueIdentifier>{421903d2-bf47-4521-92d6-46b4c91a727d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\decomp\tools\stb">
+      <UniqueIdentifier>{e0023ccb-fe92-4b65-a83e-c005d93e95b2}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\debug_print.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\gfx_adapter.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\gfx_adapter_commands.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\gfx_macros.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\libsm64.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\load_anim_data.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\load_surfaces.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\load_tex_data.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\obj_pool.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\global_state.h">
+      <Filter>Source Files\decomp</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\memory.h">
+      <Filter>Source Files\decomp</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\shim.h">
+      <Filter>Source Files\decomp</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\engine\geo_layout.h">
+      <Filter>Source Files\decomp\engine</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\engine\graph_node.h">
+      <Filter>Source Files\decomp\engine</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\engine\guMtxF2L.h">
+      <Filter>Source Files\decomp\engine</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\engine\math_util.h">
+      <Filter>Source Files\decomp\engine</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\engine\surface_collision.h">
+      <Filter>Source Files\decomp\engine</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\area.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\behavior_actions.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\camera.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\interaction.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\level_update.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\mario.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\mario_actions_airborne.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\mario_actions_automatic.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\mario_actions_cutscene.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\mario_actions_moving.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\mario_actions_object.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\mario_actions_stationary.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\mario_actions_submerged.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\mario_misc.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\mario_step.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\object_stuff.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\platform_displacement.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\rendering_graph_node.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\game\save_file.h">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\audio_defines.h">
+      <Filter>Source Files\decomp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\command_macros_base.h">
+      <Filter>Source Files\decomp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\geo_commands.h">
+      <Filter>Source Files\decomp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\level_misc_macros.h">
+      <Filter>Source Files\decomp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\macros.h">
+      <Filter>Source Files\decomp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\mario_animation_ids.h">
+      <Filter>Source Files\decomp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\mario_geo_switch_case_ids.h">
+      <Filter>Source Files\decomp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\object_fields.h">
+      <Filter>Source Files\decomp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\platform_info.h">
+      <Filter>Source Files\decomp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\seq_ids.h">
+      <Filter>Source Files\decomp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\sm64.h">
+      <Filter>Source Files\decomp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\special_preset_names.h">
+      <Filter>Source Files\decomp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\surface_terrains.h">
+      <Filter>Source Files\decomp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\types.h">
+      <Filter>Source Files\decomp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\PR\gbi.h">
+      <Filter>Source Files\decomp\include\PR</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\PR\os_cont.h">
+      <Filter>Source Files\decomp\include\PR</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\include\PR\ultratypes.h">
+      <Filter>Source Files\decomp\include\PR</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\mario\geo.inc.h">
+      <Filter>Source Files\decomp\mario</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\mario\model.inc.h">
+      <Filter>Source Files\decomp\mario</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\tools\libmio0.h">
+      <Filter>Source Files\decomp\tools</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\tools\n64graphics.h">
+      <Filter>Source Files\decomp\tools</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\tools\utils.h">
+      <Filter>Source Files\decomp\tools</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\tools\stb\stb_image.h">
+      <Filter>Source Files\decomp\tools\stb</Filter>
+    </ClInclude>
+    <ClInclude Include="src\decomp\tools\stb\stb_image_write.h">
+      <Filter>Source Files\decomp\tools\stb</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\debug_print.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\gfx_adapter.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\libsm64.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\load_anim_data.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\load_surfaces.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\load_tex_data.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\obj_pool.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\global_state.c">
+      <Filter>Source Files\decomp</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\memory.c">
+      <Filter>Source Files\decomp</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\engine\geo_layout.c">
+      <Filter>Source Files\decomp\engine</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\engine\graph_node.c">
+      <Filter>Source Files\decomp\engine</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\engine\graph_node_manager.c">
+      <Filter>Source Files\decomp\engine</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\engine\guMtxF2L.c">
+      <Filter>Source Files\decomp\engine</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\engine\math_util.c">
+      <Filter>Source Files\decomp\engine</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\engine\surface_collision.c">
+      <Filter>Source Files\decomp\engine</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\game\behavior_actions.c">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\game\interaction.c">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\game\mario.c">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\game\mario_actions_airborne.c">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\game\mario_actions_automatic.c">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\game\mario_actions_cutscene.c">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\game\mario_actions_moving.c">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\game\mario_actions_object.c">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\game\mario_actions_stationary.c">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\game\mario_actions_submerged.c">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\game\mario_misc.c">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\game\mario_step.c">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\game\object_stuff.c">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\game\platform_displacement.c">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\game\rendering_graph_node.c">
+      <Filter>Source Files\decomp\game</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\mario\geo.inc.c">
+      <Filter>Source Files\decomp\mario</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\mario\model.inc.c">
+      <Filter>Source Files\decomp\mario</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\tools\libmio0.c">
+      <Filter>Source Files\decomp\tools</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\tools\n64graphics.c">
+      <Filter>Source Files\decomp\tools</Filter>
+    </ClCompile>
+    <ClCompile Include="src\decomp\tools\utils.c">
+      <Filter>Source Files\decomp\tools</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/src/decomp/engine/graph_node.c
+++ b/src/decomp/engine/graph_node.c
@@ -745,6 +745,16 @@ void geo_obj_init_animation(struct GraphNodeObject *graphNode, struct Animation 
     }
 }
 
+/*
+* unary minus operator applied to unsigned type
+* I'm not sure what the intended behavior here is,
+* so I'm going to play it safe and just disable the warning
+*/
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4146)
+#endif
+
 /**
  * Initialize the animation of an object node
  */
@@ -762,6 +772,10 @@ void geo_obj_init_animation_accel(struct GraphNodeObject *graphNode, struct Anim
 
     graphNode->animInfo.animAccel = animAccel;
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 /**
  * Retrieves an index into animation data based on the attribute pointer

--- a/src/decomp/engine/math_util.c
+++ b/src/decomp/engine/math_util.c
@@ -1446,8 +1446,13 @@ int gSplineState;
 
 // These functions have bogus return values.
 // Disable the compiler warning.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4172)
+#else
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wreturn-local-addr"
+#endif
 
 /// Copy vector 'src' to 'dest'
 void *vec3f_copy(Vec3f dest, Vec3f src) {
@@ -1572,7 +1577,11 @@ void *vec3f_normalize(Vec3f dest) {
     return &dest; //! warning: function returns address of local variable
 }
 
+#ifdef _MSC_VER
+#pragma warning(pop)
+#else
 #pragma GCC diagnostic pop
+#endif
 
 /// Copy matrix 'src' to 'dest'
 void mtxf_copy(Mat4 dest, Mat4 src) {
@@ -2185,9 +2194,13 @@ s16 atan2s(f32 y, f32 x) {
 /**
  * Compute the atan2 in radians by calling atan2s and converting the result.
  */
-f32 atan2f(f32 y, f32 x) {
-    return (f32) atan2s(y, x) * M_PI / 0x8000;
-}
+/* HACK: I have genuinely no idea why MSVC complains that this function already has a body
+* If this function will need to be used, this will need to solved
+* f32 atan2f(f32 y, f32 x) 
+* {
+*     return (f32)atan2s(y, x) * (float)M_PI / 0x8000;
+* }
+*/
 
 #define CURVE_BEGIN_1 1
 #define CURVE_BEGIN_2 2

--- a/src/decomp/engine/math_util.h
+++ b/src/decomp/engine/math_util.h
@@ -28,6 +28,12 @@ extern f32 gCosineTable[];
 #define sins(x) gSineTable[(u16) (x) >> 4]
 #define coss(x) gCosineTable[(u16) (x) >> 4]
 
+/* Resolve conflict with Windows SDK */
+#ifdef _MSC_VER
+#undef min
+#undef max
+#endif
+
 #define min(a, b) ((a) <= (b) ? (a) : (b))
 #define max(a, b) ((a) > (b) ? (a) : (b))
 
@@ -68,7 +74,7 @@ void vec3f_set_dist_and_angle(Vec3f from, Vec3f to, f32  dist, s16  pitch, s16  
 s32 approach_s32(s32 current, s32 target, s32 inc, s32 dec);
 f32 approach_f32(f32 current, f32 target, f32 inc, f32 dec);
 s16 atan2s(f32 y, f32 x);
-f32 atan2f(f32 a, f32 b);
+f32 atan2f(f32 y, f32 x);
 void spline_get_weights(Vec4f result, f32 t, UNUSED s32 c);
 void anim_spline_init(Vec4s *keyFrames);
 s32 anim_spline_poll(Vec3f result);

--- a/src/decomp/game/object_stuff.c
+++ b/src/decomp/game/object_stuff.c
@@ -80,10 +80,15 @@ static struct Object *allocate_object(void) {
     obj->collidedObjInteractTypes = 0;
     obj->numCollidedObjs = 0;
 
+#if IS_64_BIT
     for (i = 0; i < 0x50; i++) {
         obj->rawData.asS32[i] = 0;
         obj->ptrData.asVoidPtr[i] = NULL;
     }
+#else
+    // -O2 needs everything until = on the same line
+    for (i = 0; i < 0x50; i++) obj->rawData.asS32[i] = 0;
+#endif
 
     obj->unused1 = 0;
     obj->bhvStackIndex = 0;

--- a/src/decomp/include/platform_info.h
+++ b/src/decomp/include/platform_info.h
@@ -7,7 +7,11 @@
 #else
 #include <stdint.h>
 #define IS_64_BIT (UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFU)
+#ifdef _MSC_VER
+#define IS_BIG_ENDIAN 0
+#else
 #define IS_BIG_ENDIAN (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#endif
 #endif
 
 #define DOUBLE_SIZE_ON_64_BIT(size) ((size) * (sizeof(void *) / 4))

--- a/src/decomp/tools/n64graphics.c
+++ b/src/decomp/tools/n64graphics.c
@@ -1,6 +1,10 @@
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef _MSC_VER
+#include <string.h>
+#else
 #include <strings.h>
+#endif
 
 #define STBI_NO_LINEAR
 #define STBI_NO_HDR

--- a/src/decomp/tools/utils.c
+++ b/src/decomp/tools/utils.c
@@ -1,4 +1,6 @@
+#ifndef _MSC_VER
 #include <dirent.h>
+#endif
 #include <fcntl.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -224,6 +226,7 @@ long copy_file(const char *src_name, const char *dst_name)
 
 void dir_list_ext(const char *dir, const char *extension, dir_list *list)
 {
+#ifndef _MSC_VER
    char *pool;
    char *pool_ptr;
    struct dirent *entry;
@@ -251,6 +254,7 @@ void dir_list_ext(const char *dir, const char *extension, dir_list *list)
    list->count = idx;
 
    closedir(dfd);
+#endif
 }
 
 void dir_list_free(dir_list *list)

--- a/src/decomp/tools/utils.h
+++ b/src/decomp/tools/utils.h
@@ -69,6 +69,11 @@ typedef struct
 // global verbosity setting
 extern int g_verbosity;
 
+/* Resolve conflict with Windows SDK */
+#ifdef _MSC_VER
+#undef ERROR
+#endif
+
 #define ERROR(...) fprintf(stderr, __VA_ARGS__)
 #define INFO(...) if (g_verbosity) printf(__VA_ARGS__)
 #define INFO_HEX(...) if (g_verbosity) print_hex(__VA_ARGS__)

--- a/src/gfx_adapter.c
+++ b/src/gfx_adapter.c
@@ -41,7 +41,7 @@ static void convert_uv_to_atlas( float *atlas_uv_out, short tc[] )
 
 static void process_display_list( void *dl )
 {
-    int64_t *ptr = (int64_t *)dl;
+    intptr_t *ptr = (intptr_t *)dl;
     Vtx *vdata = NULL;
 
     for( ;; )
@@ -50,19 +50,19 @@ static void process_display_list( void *dl )
         {
             case GFXCMD_VertexData: 
             {
-                UNUSED int64_t v = *ptr++;
-                UNUSED int64_t n = *ptr++;
-                UNUSED int64_t v0 = *ptr++;
+                UNUSED intptr_t v = *ptr++;
+                UNUSED intptr_t n = *ptr++;
+                UNUSED intptr_t v0 = *ptr++;
                 vdata = (Vtx*)v;
                 break;
             }
 
             case GFXCMD_Triangle:
             {
-                int64_t v00 = *ptr++;
-                int64_t v01 = *ptr++;
-                int64_t v02 = *ptr++;
-                UNUSED int64_t flag0 = *ptr++;
+                intptr_t v00 = *ptr++;
+                intptr_t v01 = *ptr++;
+                intptr_t v02 = *ptr++;
+                UNUSED intptr_t flag0 = *ptr++;
 
                 short x0 = vdata[v00].v.ob[0], y0 = vdata[v00].v.ob[1], z0 = vdata[v00].v.ob[2];
                 short x1 = vdata[v01].v.ob[0], y1 = vdata[v01].v.ob[1], z1 = vdata[v01].v.ob[2];
@@ -129,8 +129,8 @@ static void process_display_list( void *dl )
 
             case GFXCMD_Light:
             {
-                int64_t l = *ptr++;
-                int64_t n = *ptr++;
+                intptr_t l = *ptr++;
+                intptr_t n = *ptr++;
 
                 if( n == 1 )
                 {
@@ -145,9 +145,9 @@ static void process_display_list( void *dl )
 
             case GFXCMD_Texture:
             {
-                int64_t s = *ptr++;
-                int64_t t = *ptr++;
-                int64_t on = *ptr++;
+                intptr_t s = *ptr++;
+                intptr_t t = *ptr++;
+                intptr_t on = *ptr++;
 
                 s_scaleS = (uint16_t)s;
                 s_scaleT = (uint16_t)t;
@@ -158,7 +158,7 @@ static void process_display_list( void *dl )
 
             case GFXCMD_SetTextureImage:
             {
-                int64_t i = *ptr++;
+                intptr_t i = *ptr++;
 
                 s_textureIndex = (int)i;
                 s_texWidth = mario_tex_widths[s_textureIndex];
@@ -169,8 +169,8 @@ static void process_display_list( void *dl )
 
             case GFXCMD_SetTileSize:
             {
-                int64_t uls = *ptr++;
-                int64_t ult = *ptr++;
+                intptr_t uls = *ptr++;
+                intptr_t ult = *ptr++;
                 ptr++; // lrs
                 ptr++; // lrt
 
@@ -182,7 +182,7 @@ static void process_display_list( void *dl )
 
             case GFXCMD_SubDisplayList:
             {
-                int64_t dl = *ptr++;
+                intptr_t dl = *ptr++;
                 process_display_list( (void*)dl );
                 break;
             }

--- a/src/gfx_adapter.h
+++ b/src/gfx_adapter.h
@@ -4,11 +4,11 @@
 #include "libsm64.h"
 
 // Commented out in gbi.h - Replaced here 
-#define gDPPipeSync(pkt) ({})
-#define gSPSetGeometryMode(pkt, word) ({})
-#define gSPClearGeometryMode(pkt, word) ({})
-#define gDPFillRectangle(pkt, ulx, uly, lrx, lry) ({})
-#define gSPViewport(pkt, v) ({})
+#define gDPPipeSync(pkt) { }
+#define gSPSetGeometryMode(pkt, word) {}
+#define gSPClearGeometryMode(pkt, word) {}
+#define gDPFillRectangle(pkt, ulx, uly, lrx, lry) {}
+#define gSPViewport(pkt, v) {}
 extern void gSPMatrix( void *pkt, Mtx *m, uint8_t flags );
 extern void gSPDisplayList( void *pkt, struct DisplayListNode *dl );
 

--- a/src/gfx_macros.h
+++ b/src/gfx_macros.h
@@ -78,7 +78,7 @@ typedef struct {
 
 #define gsSPVertex(v, n, v0) \
     GFXCMD_VertexData, \
-    (int64_t)v, n, v0
+    (intptr_t)v, n, v0
 
 #define gsSP2Triangles(v00, v01, v02, flag0, v10, v11, v12, flag1) \
     GFXCMD_Triangle, \
@@ -95,11 +95,11 @@ typedef struct {
 
 #define gsSPDisplayList(dl) \
     GFXCMD_SubDisplayList, \
-    (int64_t)dl
+    (intptr_t)dl
 
 #define gsSPLight(l, n) \
     GFXCMD_Light, \
-    (int64_t)l, n
+    (intptr_t)l, n
 
 #define gsSPTexture(s, t, level, tile, on) \
     GFXCMD_Texture, \
@@ -125,4 +125,4 @@ typedef struct {
 #define gsDPLoadBlock(tile, uls, ult, lrs, dxt) (GFXCMD_None)
 #define gsDPLoadSync() (GFXCMD_None)
 
-typedef int64_t Gfx;
+typedef intptr_t Gfx;

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -6,13 +6,9 @@
 #include <stdbool.h>
 
 #ifdef _WIN32
-    #ifdef SM64_LIB_EXPORT
-        #define SM64_LIB_FN __declspec(dllexport)
-    #else
-        #define SM64_LIB_FN __declspec(dllimport)
-    #endif
+	#define SM64_LIB_FN __declspec(dllexport)
 #else
-    #define SM64_LIB_FN
+	#define SM64_LIB_FN
 #endif
 
 struct SM64Surface
@@ -69,6 +65,11 @@ enum
     SM64_GEO_MAX_TRIANGLES = 1024,
 };
 
+#ifdef __cplusplus
+extern "C" 
+{
+#endif
+
 extern SM64_LIB_FN void sm64_global_init( uint8_t *rom, uint8_t *outTexture, SM64DebugPrintFunctionPtr debugPrintFunction );
 extern SM64_LIB_FN void sm64_global_terminate( void );
 
@@ -81,5 +82,9 @@ extern SM64_LIB_FN void sm64_mario_delete( int32_t marioId );
 extern SM64_LIB_FN uint32_t sm64_surface_object_create( const struct SM64SurfaceObject *surfaceObject );
 extern SM64_LIB_FN void sm64_surface_object_move( uint32_t objectId, const struct SM64ObjectTransform *transform );
 extern SM64_LIB_FN void sm64_surface_object_delete( uint32_t objectId );
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif//LIB_SM64_H


### PR DESCRIPTION
I added support for building this as a static library using Visual Studio 2019 (MSVC v142), and I also fixed the build not working for 32 bit. Linking the library against a project built in C++ was also fixed.

I have tested the build on x86/x64 Release on VS2019 and x86 under MinGW.