### PR TITLE
Exposed libsm64's raycasting/collision logic via its API.

### DIFF
--- a/src/decomp/engine/math_util.c
+++ b/src/decomp/engine/math_util.c
@@ -1840,7 +1840,7 @@ void mtxf_align_terrain_normal(Mat4 dest, Vec3f upDir, Vec3f pos, s16 yaw) {
  * 'radius' is the distance from each triangle vertex to the center
  */
 void mtxf_align_terrain_triangle(Mat4 mtx, Vec3f pos, s16 yaw, f32 radius) {
-    struct Surface *sp74;
+    struct SM64SurfaceCollisionData *sp74;
     Vec3f point0;
     Vec3f point1;
     Vec3f point2;

--- a/src/decomp/engine/surface_collision.c
+++ b/src/decomp/engine/surface_collision.c
@@ -6,10 +6,10 @@
 /**
  * Iterate through the list of ceilings and find the first ceiling over a given point.
  */
-static struct Surface *find_ceil_from_list( s32 x, s32 y, s32 z, f32 *pheight) {
-    register struct Surface *surf;
+static struct SM64SurfaceCollisionData *find_ceil_from_list( s32 x, s32 y, s32 z, f32 *pheight) {
+    register struct SM64SurfaceCollisionData *surf;
     register s32 x1, z1, x2, z2, x3, z3;
-    struct Surface *ceil = NULL;
+    struct SM64SurfaceCollisionData *ceil = NULL;
 
     ceil = NULL;
 
@@ -81,13 +81,13 @@ static struct Surface *find_ceil_from_list( s32 x, s32 y, s32 z, f32 *pheight) {
 /**
  * Iterate through the list of floors and find the first floor under a given point.
  */
-static struct Surface *find_floor_from_list( s32 x, s32 y, s32 z, f32 *pheight) {
-    register struct Surface *surf;
+static struct SM64SurfaceCollisionData *find_floor_from_list( s32 x, s32 y, s32 z, f32 *pheight) {
+    register struct SM64SurfaceCollisionData *surf;
     register s32 x1, z1, x2, z2, x3, z3;
     f32 nx, ny, nz;
     f32 oo;
     f32 height;
-    struct Surface *floor = NULL;
+    struct SM64SurfaceCollisionData *floor = NULL;
 
     uint32_t groupCount = loaded_surface_iter_group_count();
     for( int i = 0; i < groupCount; ++i ) {
@@ -148,8 +148,8 @@ static struct Surface *find_floor_from_list( s32 x, s32 y, s32 z, f32 *pheight) 
     return floor;
 }
 
-static s32 find_wall_collisions_from_list( struct WallCollisionData *data) {
-    register struct Surface *surf;
+static s32 find_wall_collisions_from_list( struct SM64WallCollisionData *data) {
+    register struct SM64SurfaceCollisionData *surf;
     register f32 offset;
     register f32 radius = data->radius;
     register f32 x = data->x;
@@ -270,7 +270,7 @@ static s32 find_wall_collisions_from_list( struct WallCollisionData *data) {
 
 s32 f32_find_wall_collision(f32 *xPtr, f32 *yPtr, f32 *zPtr, f32 offsetY, f32 radius)
 {
-    struct WallCollisionData collision;
+    struct SM64WallCollisionData collision;
     s32 numCollisions = 0;
 
     collision.offsetY = offsetY;
@@ -291,7 +291,7 @@ s32 f32_find_wall_collision(f32 *xPtr, f32 *yPtr, f32 *zPtr, f32 offsetY, f32 ra
     return numCollisions;
 }
 
-s32 find_wall_collisions(struct WallCollisionData *colData)
+s32 find_wall_collisions(struct SM64WallCollisionData *colData)
 {
     s32 numCollisions = 0;
     colData->numWalls = 0;
@@ -310,18 +310,18 @@ s32 find_wall_collisions(struct WallCollisionData *colData)
     return numCollisions;
 }
 
-f32 find_ceil(f32 posX, f32 posY, f32 posZ, struct Surface **pceil)
+f32 find_ceil(f32 posX, f32 posY, f32 posZ, struct SM64SurfaceCollisionData **pceil)
 {
     f32 height = CELL_HEIGHT_LIMIT;
 	*pceil = find_ceil_from_list( posX, posY, posZ, &height );
 	return height;
 }
 
-struct FloorGeometry sFloorGeo;
+struct SM64FloorCollisionData sFloorGeo;
 
-f32 find_floor_height_and_data(f32 xPos, f32 yPos, f32 zPos, struct FloorGeometry **floorGeo)
+f32 find_floor_height_and_data(f32 xPos, f32 yPos, f32 zPos, struct SM64FloorCollisionData **floorGeo)
 {
-    struct Surface *floor;
+    struct SM64SurfaceCollisionData *floor;
     f32 floorHeight = find_floor(xPos, yPos, zPos, &floor);
 
     *floorGeo = NULL;
@@ -344,7 +344,7 @@ f32 find_floor_height(f32 x, f32 y, f32 z)
 	return height;
 }
 
-f32 find_floor(f32 xPos, f32 yPos, f32 zPos, struct Surface **pfloor)
+f32 find_floor(f32 xPos, f32 yPos, f32 zPos, struct SM64SurfaceCollisionData **pfloor)
 {
     f32 height = FLOOR_LOWER_LIMIT;
 	*pfloor = find_floor_from_list( xPos, yPos, zPos, &height );

--- a/src/decomp/engine/surface_collision.h
+++ b/src/decomp/engine/surface_collision.h
@@ -3,6 +3,7 @@
 
 #include "../include/PR/ultratypes.h"
 
+#include "../../libsm64.h"
 #include "../include/types.h"
 
 #define LEVEL_BOUNDARY_MAX  0x2000
@@ -11,31 +12,12 @@
 #define CELL_HEIGHT_LIMIT   20000.f
 #define FLOOR_LOWER_LIMIT  -11000.f
 
-struct WallCollisionData
-{
-    /*0x00*/ f32 x, y, z;
-    /*0x0C*/ f32 offsetY;
-    /*0x10*/ f32 radius;
-    /*0x14*/ s16 unk14;
-    /*0x16*/ s16 numWalls;
-    /*0x18*/ struct Surface *walls[4];
-};
-
-struct FloorGeometry
-{
-    f32 unused[4]; // possibly position data?
-    f32 normalX;
-    f32 normalY;
-    f32 normalZ;
-    f32 originOffset;
-};
-
 s32 f32_find_wall_collision(f32 *xPtr, f32 *yPtr, f32 *zPtr, f32 offsetY, f32 radius);
-s32 find_wall_collisions(struct WallCollisionData *colData);
-f32 find_ceil(f32 posX, f32 posY, f32 posZ, struct Surface **pceil);
-f32 find_floor_height_and_data(f32 xPos, f32 yPos, f32 zPos, struct FloorGeometry **floorGeo);
+s32 find_wall_collisions(struct SM64WallCollisionData *colData);
+f32 find_ceil(f32 posX, f32 posY, f32 posZ, struct SM64SurfaceCollisionData **pceil);
+f32 find_floor_height_and_data(f32 xPos, f32 yPos, f32 zPos, struct SM64FloorCollisionData **floorGeo);
 f32 find_floor_height(f32 x, f32 y, f32 z);
-f32 find_floor(f32 xPos, f32 yPos, f32 zPos, struct Surface **pfloor);
+f32 find_floor(f32 xPos, f32 yPos, f32 zPos, struct SM64SurfaceCollisionData **pfloor);
 f32 find_water_level(f32 x, f32 z);
 f32 find_poison_gas_level(f32 x, f32 z);
 

--- a/src/decomp/game/camera.h
+++ b/src/decomp/game/camera.h
@@ -443,16 +443,16 @@ struct CutsceneSplinePoint
  */
 struct PlayerGeometry
 {
-    /*0x00*/ struct Surface *currFloor;
+    /*0x00*/ struct SM64SurfaceCollisionData *currFloor;
     /*0x04*/ f32 currFloorHeight;
     /*0x08*/ s16 currFloorType;
-    /*0x0C*/ struct Surface *currCeil;
+    /*0x0C*/ struct SM64SurfaceCollisionData *currCeil;
     /*0x10*/ s16 currCeilType;
     /*0x14*/ f32 currCeilHeight;
-    /*0x18*/ struct Surface *prevFloor;
+    /*0x18*/ struct SM64SurfaceCollisionData *prevFloor;
     /*0x1C*/ f32 prevFloorHeight;
     /*0x20*/ s16 prevFloorType;
-    /*0x24*/ struct Surface *prevCeil;
+    /*0x24*/ struct SM64SurfaceCollisionData *prevCeil;
     /*0x28*/ f32 prevCeilHeight;
     /*0x2C*/ s16 prevCeilType;
     /// Unused, but recalculated every frame
@@ -716,7 +716,7 @@ struct LakituState
 // f32 camera_approach_f32_symmetric(f32 value, f32 target, f32 increment);
 // void random_vec3s(Vec3s dst, s16 xRange, s16 yRange, s16 zRange);
 // s32 clamp_positions_and_find_yaw(Vec3f pos, Vec3f origin, f32 xMax, f32 xMin, f32 zMax, f32 zMin);
-// s32 is_range_behind_surface(Vec3f from, Vec3f to, struct Surface *surf, s16 range, s16 surfType);
+// s32 is_range_behind_surface(Vec3f from, Vec3f to, struct SM64SurfaceCollisionData *surf, s16 range, s16 surfType);
 // void scale_along_line(Vec3f dest, Vec3f from, Vec3f to, f32 scale);
 // s16 calculate_pitch(Vec3f from, Vec3f to);
 // s16 calculate_yaw(Vec3f from, Vec3f to);

--- a/src/decomp/game/interaction.c
+++ b/src/decomp/game/interaction.c
@@ -609,7 +609,7 @@ void push_mario_out_of_object(struct MarioState *m, struct Object *o, f32 paddin
     f32 distance = sqrtf(offsetX * offsetX + offsetZ * offsetZ);
 
     if (distance < minDistance) {
-        struct Surface *floor;
+        struct SM64SurfaceCollisionData *floor;
         s16 pushAngle;
         f32 newMarioX;
         f32 newMarioZ;

--- a/src/decomp/game/mario.c
+++ b/src/decomp/game/mario.c
@@ -527,9 +527,9 @@ u32 mario_get_terrain_sound_addend(struct MarioState *m) {
 /**
  * Collides with walls and returns the most recent wall.
  */
-struct Surface *resolve_and_return_wall_collisions(Vec3f pos, f32 offset, f32 radius) {
-    struct WallCollisionData collisionData;
-    struct Surface *wall = NULL;
+struct SM64SurfaceCollisionData *resolve_and_return_wall_collisions(Vec3f pos, f32 offset, f32 radius) {
+    struct SM64WallCollisionData collisionData;
+    struct SM64SurfaceCollisionData *wall = NULL;
 
     collisionData.x = pos[0];
     collisionData.y = pos[1];
@@ -553,7 +553,7 @@ struct Surface *resolve_and_return_wall_collisions(Vec3f pos, f32 offset, f32 ra
 /**
  * Finds the ceiling from a vec3f horizontally and a height (with 80 vertical buffer).
  */
-f32 vec3f_find_ceil(Vec3f pos, f32 height, struct Surface **ceil) {
+f32 vec3f_find_ceil(Vec3f pos, f32 height, struct SM64SurfaceCollisionData **ceil) {
     UNUSED f32 unused;
 
     return find_ceil(pos[0], height + 80.0f, pos[2], ceil);
@@ -681,7 +681,7 @@ s32 mario_floor_is_steep(struct MarioState *m) {
  * Finds the floor height relative from Mario given polar displacement.
  */
 f32 find_floor_height_relative_polar(struct MarioState *m, s16 angleFromMario, f32 distFromMario) {
-    struct Surface *floor;
+    struct SM64SurfaceCollisionData *floor;
     f32 floorY;
 
     f32 y = sins(m->faceAngle[1] + angleFromMario) * distFromMario;
@@ -696,7 +696,7 @@ f32 find_floor_height_relative_polar(struct MarioState *m, s16 angleFromMario, f
  * Returns the slope of the floor based off points around Mario.
  */
 s16 find_floor_slope(struct MarioState *m, s16 yawOffset) {
-    struct Surface *floor;
+    struct SM64SurfaceCollisionData *floor;
     f32 forwardFloorY, backwardFloorY;
     f32 forwardYDelta, backwardYDelta;
     s16 result;

--- a/src/decomp/game/mario.h
+++ b/src/decomp/game/mario.h
@@ -28,8 +28,8 @@ void play_mario_sound(struct MarioState *m, s32 primarySoundBits, s32 scondarySo
 void mario_set_forward_vel(struct MarioState *m, f32 speed);
 s32 mario_get_floor_class(struct MarioState *m);
 u32 mario_get_terrain_sound_addend(struct MarioState *m);
-struct Surface *resolve_and_return_wall_collisions(Vec3f pos, f32 offset, f32 radius);
-f32 vec3f_find_ceil(Vec3f pos, f32 height, struct Surface **ceil);
+struct SM64SurfaceCollisionData *resolve_and_return_wall_collisions(Vec3f pos, f32 offset, f32 radius);
+f32 vec3f_find_ceil(Vec3f pos, f32 height, struct SM64SurfaceCollisionData **ceil);
 s32 mario_facing_downhill(struct MarioState *m, s32 turnYaw);
 u32 mario_floor_is_slippery(struct MarioState *m);
 s32 mario_floor_is_slope(struct MarioState *m);

--- a/src/decomp/game/mario_actions_airborne.c
+++ b/src/decomp/game/mario_actions_airborne.c
@@ -115,7 +115,7 @@ s32 check_kick_or_dive_in_air(struct MarioState *m) {
 }
 
 s32 should_get_stuck_in_ground(struct MarioState *m) {
-    struct Surface *floor = m->floor;
+    struct SM64SurfaceCollisionData *floor = m->floor;
     s32 flags = floor->flags;
     s32 type = floor->type;
 
@@ -148,7 +148,7 @@ s32 check_fall_damage_or_get_stuck(struct MarioState *m, u32 hardFallAction) {
 }
 
 s32 check_horizontal_wind(struct MarioState *m) {
-    struct Surface *floor;
+    struct SM64SurfaceCollisionData *floor;
     f32 speed;
     s16 pushAngle;
 

--- a/src/decomp/game/mario_actions_automatic.c
+++ b/src/decomp/game/mario_actions_automatic.c
@@ -65,8 +65,8 @@ s32 set_pole_position(struct MarioState *m, f32 offsetY) {
     UNUSED s32 unused1;
     UNUSED s32 unused2;
     UNUSED s32 unused3;
-    struct Surface *floor;
-    struct Surface *ceil;
+    struct SM64SurfaceCollisionData *floor;
+    struct SM64SurfaceCollisionData *ceil;
     f32 floorHeight;
     f32 ceilHeight;
     s32 collided;
@@ -307,8 +307,8 @@ s32 act_top_of_pole(struct MarioState *m) {
 
 s32 perform_hanging_step(struct MarioState *m, Vec3f nextPos) {
     UNUSED s32 unused;
-    struct Surface *ceil;
-    struct Surface *floor;
+    struct SM64SurfaceCollisionData *ceil;
+    struct SM64SurfaceCollisionData *floor;
     f32 ceilHeight;
     f32 floorHeight;
     f32 ceilOffset;
@@ -498,7 +498,7 @@ s32 act_hang_moving(struct MarioState *m) {
 
 s32 let_go_of_ledge(struct MarioState *m) {
     f32 floorHeight;
-    struct Surface *floor;
+    struct SM64SurfaceCollisionData *floor;
 
     m->vel[1] = 0.0f;
     m->forwardVel = -8.0f;
@@ -772,7 +772,7 @@ s32 act_in_cannon(struct MarioState *m) {
 }
 
 s32 act_tornado_twirling(struct MarioState *m) {
-    struct Surface *floor;
+    struct SM64SurfaceCollisionData *floor;
     Vec3f nextPos;
     f32 sinAngleVel;
     f32 cosAngleVel;

--- a/src/decomp/game/mario_actions_cutscene.c
+++ b/src/decomp/game/mario_actions_cutscene.c
@@ -567,7 +567,7 @@ s32 act_reading_sign(struct MarioState *m) {
 s32 act_debug_free_move(struct MarioState *m) {
     struct Controller *gPlayer1Controller = &gController;
 
-    struct Surface *surf;
+    struct SM64SurfaceCollisionData *surf;
     f32 floorHeight;
     Vec3f pos;
     f32 speed;
@@ -2014,7 +2014,7 @@ void generate_yellow_sparkles(s16 x, s16 y, s16 z, f32 radius) {
 // not sure what this does, returns the height of the floor.
 // (animation related?)
 // static f32 end_obj_set_visual_pos(struct Object *o) {
-//     struct Surface *surf;
+//     struct SM64SurfaceCollisionData *surf;
 //     Vec3s sp24;
 //     f32 sp20;
 //     f32 sp1C;
@@ -2178,7 +2178,7 @@ static void end_peach_cutscene_descend_peach(struct MarioState *m) {
 
 // Mario runs to peach
 static void end_peach_cutscene_run_to_peach(struct MarioState *m) {
-    struct Surface *surf;
+    struct SM64SurfaceCollisionData *surf;
 
     if (m->actionTimer == 22) {
         sEndPeachAnimation = 5;

--- a/src/decomp/game/mario_actions_moving.c
+++ b/src/decomp/game/mario_actions_moving.c
@@ -102,10 +102,10 @@ s32 begin_walking_action(struct MarioState *m, f32 forwardVel, u32 action, u32 a
 }
 
 void check_ledge_climb_down(struct MarioState *m) {
-    struct WallCollisionData wallCols;
-    struct Surface *floor;
+    struct SM64WallCollisionData wallCols;
+    struct SM64SurfaceCollisionData *floor;
     f32 floorHeight;
-    struct Surface *wall;
+    struct SM64SurfaceCollisionData *wall;
     s16 wallAngle;
     s16 wallDYaw;
 
@@ -164,7 +164,7 @@ void update_sliding_angle(struct MarioState *m, f32 accel, f32 lossFactor) {
     s32 newFacingDYaw;
     s16 facingDYaw;
 
-    struct Surface *floor = m->floor;
+    struct SM64SurfaceCollisionData *floor = m->floor;
     s16 slopeAngle = atan2s(floor->normal.z, floor->normal.x);
     f32 steepness = sqrtf(floor->normal.x * floor->normal.x + floor->normal.z * floor->normal.z);
     UNUSED f32 normalY = floor->normal.y;
@@ -287,7 +287,7 @@ s32 update_sliding(struct MarioState *m, f32 stopSpeed) {
 void apply_slope_accel(struct MarioState *m) {
     f32 slopeAccel;
 
-    struct Surface *floor = m->floor;
+    struct SM64SurfaceCollisionData *floor = m->floor;
     f32 steepness = sqrtf(floor->normal.x * floor->normal.x + floor->normal.z * floor->normal.z);
 
     UNUSED f32 normalY = floor->normal.y;

--- a/src/decomp/game/mario_actions_submerged.c
+++ b/src/decomp/game/mario_actions_submerged.c
@@ -80,9 +80,9 @@ static f32 get_buoyancy(struct MarioState *m) {
 }
 
 static u32 perform_water_full_step(struct MarioState *m, Vec3f nextPos) {
-    struct Surface *wall;
-    struct Surface *ceil;
-    struct Surface *floor;
+    struct SM64SurfaceCollisionData *wall;
+    struct SM64SurfaceCollisionData *ceil;
+    struct SM64SurfaceCollisionData *floor;
     f32 ceilHeight;
     f32 floorHeight;
 

--- a/src/decomp/game/mario_step.c
+++ b/src/decomp/game/mario_step.c
@@ -10,7 +10,7 @@
 
 static s16 sMovingSandSpeeds[] = { 12, 8, 4, 0 };
 
-struct Surface gWaterSurfacePseudoFloor = {
+struct SM64SurfaceCollisionData gWaterSurfacePseudoFloor = {
     SURFACE_VERY_SLIPPERY, 0,    0,    0, 0, 0, { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 },
     { 0.0f, 1.0f, 0.0f },  0.0f, 0, NULL, 0
 };
@@ -169,7 +169,7 @@ u32 mario_push_off_steep_floor(struct MarioState *m, u32 action, u32 actionArg) 
 }
 
 u32 mario_update_moving_sand(struct MarioState *m) {
-    struct Surface *floor = m->floor;
+    struct SM64SurfaceCollisionData *floor = m->floor;
     s32 floorType = floor->type;
 
     if (floorType == SURFACE_DEEP_MOVING_QUICKSAND || floorType == SURFACE_SHALLOW_MOVING_QUICKSAND
@@ -187,7 +187,7 @@ u32 mario_update_moving_sand(struct MarioState *m) {
 }
 
 u32 mario_update_windy_ground(struct MarioState *m) {
-    struct Surface *floor = m->floor;
+    struct SM64SurfaceCollisionData *floor = m->floor;
 
     if (floor->type == SURFACE_HORIZONTAL_WIND) {
         f32 pushSpeed;
@@ -255,10 +255,10 @@ s32 stationary_ground_step(struct MarioState *m) {
 }
 
 static s32 perform_ground_quarter_step(struct MarioState *m, Vec3f nextPos) {
-    UNUSED struct Surface *lowerWall;
-    struct Surface *upperWall;
-    struct Surface *ceil;
-    struct Surface *floor;
+    UNUSED struct SM64SurfaceCollisionData *lowerWall;
+    struct SM64SurfaceCollisionData *upperWall;
+    struct SM64SurfaceCollisionData *ceil;
+    struct SM64SurfaceCollisionData *floor;
     f32 ceilHeight;
     f32 floorHeight;
     f32 waterLevel;
@@ -344,8 +344,8 @@ s32 perform_ground_step(struct MarioState *m) {
     return stepResult;
 }
 
-u32 check_ledge_grab(struct MarioState *m, struct Surface *wall, Vec3f intendedPos, Vec3f nextPos) {
-    struct Surface *ledgeFloor;
+u32 check_ledge_grab(struct MarioState *m, struct SM64SurfaceCollisionData *wall, Vec3f intendedPos, Vec3f nextPos) {
+    struct SM64SurfaceCollisionData *ledgeFloor;
     Vec3f ledgePos;
     f32 displacementX;
     f32 displacementZ;
@@ -387,10 +387,10 @@ u32 check_ledge_grab(struct MarioState *m, struct Surface *wall, Vec3f intendedP
 s32 perform_air_quarter_step(struct MarioState *m, Vec3f intendedPos, u32 stepArg) {
     s16 wallDYaw;
     Vec3f nextPos;
-    struct Surface *upperWall;
-    struct Surface *lowerWall;
-    struct Surface *ceil;
-    struct Surface *floor;
+    struct SM64SurfaceCollisionData *upperWall;
+    struct SM64SurfaceCollisionData *lowerWall;
+    struct SM64SurfaceCollisionData *ceil;
+    struct SM64SurfaceCollisionData *floor;
     f32 ceilHeight;
     f32 floorHeight;
     f32 waterLevel;

--- a/src/decomp/game/mario_step.h
+++ b/src/decomp/game/mario_step.h
@@ -14,7 +14,7 @@ struct BullyCollisionData {
   /*0x14*/ f32 velZ;
 };
 
-extern struct Surface gWaterSurfacePseudoFloor;
+extern struct SM64SurfaceCollisionData gWaterSurfacePseudoFloor;
 
 f32 get_additive_y_vel_for_jumps(void);
 void stub_mario_step_1(struct MarioState *);

--- a/src/decomp/game/platform_displacement.c
+++ b/src/decomp/game/platform_displacement.c
@@ -17,7 +17,7 @@
  * within 4 units of the floor. Set his referenced platform object accordingly.
  */
 void update_mario_platform(void) {
-    struct Surface *floor;
+    struct SM64SurfaceCollisionData *floor;
     UNUSED u32 unused;
     f32 marioX;
     f32 marioY;
@@ -82,7 +82,7 @@ static void set_mario_pos(f32 x, f32 y, f32 z) {
  * Apply one frame of platform rotation to Mario or an object using the given
  * platform. If isMario is false, use gCurrentObject.
  */
-void apply_platform_displacement(u32 isMario, struct SurfaceObjectTransform *platform) {
+void apply_platform_displacement(u32 isMario, struct SM64SurfaceObjectTransform *platform) {
     f32 x;
     f32 y;
     f32 z;

--- a/src/decomp/include/types.h
+++ b/src/decomp/include/types.h
@@ -85,21 +85,6 @@ enum SpTaskState {
 #define ANIM_FLAG_6          (1 << 6) // 0x40
 #define ANIM_FLAG_7          (1 << 7) // 0x80
 
-// Added by libsm64
-struct SurfaceObjectTransform
-{
-    float aPosX, aPosY, aPosZ;
-    float aVelX, aVelY, aVelZ;
-
-    s16 aFaceAnglePitch;
-    s16 aFaceAngleYaw;
-    s16 aFaceAngleRoll;
-
-    s16 aAngleVelPitch;
-    s16 aAngleVelYaw;
-    s16 aAngleVelRoll;
-};
-
 struct Animation {
     /*0x00*/ s16 flags;
     /*0x02*/ s16 animYTransDivisor;
@@ -183,7 +168,7 @@ struct Object
         struct Waypoint *asWaypoint[0x50];
         struct ChainSegment *asChainSegment[0x50];
         struct Object *asObject[0x50];
-        struct Surface *asSurface[0x50];
+        struct SM64SurfaceCollisionData *asSurface[0x50];
         void *asVoidPtr[0x50];
         const void *asConstVoidPtr[0x50];
 #endif
@@ -196,7 +181,7 @@ struct Object
         struct Waypoint *asWaypoint[0x50];
         struct ChainSegment *asChainSegment[0x50];
         struct Object *asObject[0x50];
-        struct Surface *asSurface[0x50];
+        struct SM64SurfaceCollisionData *asSurface[0x50];
         void *asVoidPtr[0x50];
         const void *asConstVoidPtr[0x50];
     } ptrData;
@@ -214,7 +199,7 @@ struct Object
     /*0x208*/ f32 hitboxDownOffset;
     /*0x20C*/ const BehaviorScript *behavior;
     /*0x210*/ u32 unused2;
-    /*0x214*/ struct SurfaceObjectTransform *platform; // libsm64: type change from Object*
+    /*0x214*/ struct SM64SurfaceObjectTransform *platform; // libsm64: type change from Object*
     /*0x218*/ void *collisionData;
     /*0x21C*/ Mat4 transform;
     /*0x25C*/ void *respawnInfo;
@@ -237,30 +222,6 @@ struct Waypoint
 {
     s16 flags;
     Vec3s pos;
-};
-
-struct Surface
-{
-    s16 type;
-    s16 force;
-    s8 flags;
-    s8 room;
-    s32 lowerY; // libsm64: 32 bit
-    s32 upperY; // libsm64: 32 bit
-    Vec3i vertex1; // libsm64: 32 bit
-    Vec3i vertex2; // libsm64: 32 bit
-    Vec3i vertex3; // libsm64: 32 bit
-    struct {
-        f32 x;
-        f32 y;
-        f32 z;
-    } normal;
-    f32 originOffset;
-    //struct Object *object;
-    
-    u8 isValid; // libsm64: added field
-    struct SurfaceObjectTransform *transform; // libsm64: added field
-    u16 terrain; // libsm64: added field
 };
 
 struct MarioBodyState
@@ -328,9 +289,9 @@ struct MarioState
     /*0x54*/ f32 forwardVel;
     /*0x58*/ f32 slideVelX;
     /*0x5C*/ f32 slideVelZ;
-    /*0x60*/ struct Surface *wall;
-    /*0x64*/ struct Surface *ceil;
-    /*0x68*/ struct Surface *floor;
+    /*0x60*/ struct SM64SurfaceCollisionData *wall;
+    /*0x64*/ struct SM64SurfaceCollisionData *ceil;
+    /*0x68*/ struct SM64SurfaceCollisionData *floor;
     /*0x6C*/ f32 ceilHeight;
     /*0x70*/ f32 floorHeight;
     /*0x74*/ s16 floorAngle;

--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -85,7 +85,7 @@ SM64_LIB_FN void sm64_register_debug_print_function( SM64DebugPrintFunctionPtr d
     g_debug_print_func = debugPrintFunction;
 }
 
-typedef void (*SM64PlaySoundFunctionPtr)( uint32_t soundBits, f32 *pos );
+typedef void (*SM64PlaySoundFunctionPtr)( uint32_t soundBits, float *pos );
 SM64_LIB_FN void sm64_register_play_sound_function( SM64PlaySoundFunctionPtr playSoundFunction )
 {
     g_play_sound_func = playSoundFunction;
@@ -270,42 +270,42 @@ SM64_LIB_FN void sm64_surface_object_delete( uint32_t objectId )
 }
 
 
-SM64_LIB_FN s32 sm64_surface_find_wall_collision(f32 *xPtr, f32 *yPtr, f32 *zPtr, f32 offsetY, f32 radius) 
+SM64_LIB_FN int32_t sm64_surface_find_wall_collision( float *xPtr, float *yPtr, float *zPtr, float offsetY, float radius ) 
 {
     return f32_find_wall_collision( xPtr, yPtr, zPtr, offsetY, radius );
 }
 
-SM64_LIB_FN s32 sm64_surface_find_wall_collisions(struct WallCollisionData *colData)
+SM64_LIB_FN int32_t sm64_surface_find_wall_collisions( struct SM64WallCollisionData *colData )
 {
     return find_wall_collisions( colData );
 }
 
-SM64_LIB_FN f32 sm64_surface_find_ceil(f32 posX, f32 posY, f32 posZ, struct Surface **pceil)
+SM64_LIB_FN float sm64_surface_find_ceil( float posX, float posY, float posZ, struct SM64SurfaceCollisionData **pceil )
 {
     return find_ceil( posX, posY, posZ, pceil );
 }
 
-SM64_LIB_FN f32 sm64_surface_find_floor_height_and_data(f32 xPos, f32 yPos, f32 zPos, struct FloorGeometry **floorGeo)
+SM64_LIB_FN float sm64_surface_find_floor_height_and_data( float xPos, float yPos, float zPos, struct SM64FloorCollisionData **floorGeo )
 {
     return find_floor_height_and_data( xPos, yPos, zPos, floorGeo );
 }
 
-SM64_LIB_FN f32 sm64_surface_find_floor_height(f32 x, f32 y, f32 z)
+SM64_LIB_FN float sm64_surface_find_floor_height( float x, float y, float z )
 {
     return find_floor_height( x, y, z );
 }
 
-SM64_LIB_FN f32 sm64_surface_find_floor(f32 xPos, f32 yPos, f32 zPos, struct Surface **pfloor)
+SM64_LIB_FN float sm64_surface_find_floor( float xPos, float yPos, float zPos, struct SM64SurfaceCollisionData **pfloor )
 {
     return find_floor( xPos, yPos, zPos, pfloor );
 }
 
-SM64_LIB_FN f32 sm64_surface_find_water_level(f32 x, f32 z)
+SM64_LIB_FN float sm64_surface_find_water_level( float x, float z )
 {
     return find_water_level( x, z );
 }
 
-SM64_LIB_FN f32 sm64_surface_find_poison_gas_level(f32 x, f32 z)
+SM64_LIB_FN float sm64_surface_find_poison_gas_level( float x, float z )
 {
     return find_poison_gas_level( x, z );
 }

--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -268,3 +268,44 @@ SM64_LIB_FN void sm64_surface_object_delete( uint32_t objectId )
 
     surfaces_unload_object( objectId );
 }
+
+
+SM64_LIB_FN s32 sm64_surface_find_wall_collision(f32 *xPtr, f32 *yPtr, f32 *zPtr, f32 offsetY, f32 radius) 
+{
+    return f32_find_wall_collision( xPtr, yPtr, zPtr, offsetY, radius );
+}
+
+SM64_LIB_FN s32 sm64_surface_find_wall_collisions(struct WallCollisionData *colData)
+{
+    return find_wall_collisions( colData );
+}
+
+SM64_LIB_FN f32 sm64_surface_find_ceil(f32 posX, f32 posY, f32 posZ, struct Surface **pceil)
+{
+    return find_ceil( posX, posY, posZ, pceil );
+}
+
+SM64_LIB_FN f32 sm64_surface_find_floor_height_and_data(f32 xPos, f32 yPos, f32 zPos, struct FloorGeometry **floorGeo)
+{
+    return find_floor_height_and_data( xPos, yPos, zPos, floorGeo );
+}
+
+SM64_LIB_FN f32 sm64_surface_find_floor_height(f32 x, f32 y, f32 z)
+{
+    return find_floor_height( x, y, z );
+}
+
+SM64_LIB_FN f32 sm64_surface_find_floor(f32 xPos, f32 yPos, f32 zPos, struct Surface **pfloor)
+{
+    return find_floor( xPos, yPos, zPos, pfloor );
+}
+
+SM64_LIB_FN f32 sm64_surface_find_water_level(f32 x, f32 z)
+{
+    return find_water_level( x, z );
+}
+
+SM64_LIB_FN f32 sm64_surface_find_poison_gas_level(f32 x, f32 z)
+{
+    return find_poison_gas_level( x, z );
+}

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -5,9 +5,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include "decomp/engine/surface_collision.h"
-#include "decomp/include/types.h"
-
 #ifdef _WIN32
     #ifdef SM64_LIB_EXPORT
         #define SM64_LIB_FN __declspec(dllexport)
@@ -63,6 +60,62 @@ struct SM64MarioGeometryBuffers
     uint16_t numTrianglesUsed;
 };
 
+struct SM64WallCollisionData
+{
+    /*0x00*/ float x, y, z;
+    /*0x0C*/ float offsetY;
+    /*0x10*/ float radius;
+    /*0x14*/ int16_t unk14;
+    /*0x16*/ int16_t numWalls;
+    /*0x18*/ struct SM64SurfaceCollisionData *walls[4];
+};
+
+struct SM64FloorCollisionData
+{
+    float unused[4]; // possibly position data?
+    float normalX;
+    float normalY;
+    float normalZ;
+    float originOffset;
+};
+
+struct SM64SurfaceObjectTransform
+{
+    float aPosX, aPosY, aPosZ;
+    float aVelX, aVelY, aVelZ;
+
+    int16_t aFaceAnglePitch;
+    int16_t aFaceAngleYaw;
+    int16_t aFaceAngleRoll;
+
+    int16_t aAngleVelPitch;
+    int16_t aAngleVelYaw;
+    int16_t aAngleVelRoll;
+};
+
+struct SM64SurfaceCollisionData
+{
+    int16_t type;
+    int16_t force;
+    int8_t flags;
+    int8_t room;
+    int32_t lowerY; // libsm64: 32 bit
+    int32_t upperY; // libsm64: 32 bit
+	int32_t vertex1[3]; // libsm64: 32 bit
+	int32_t vertex2[3]; // libsm64: 32 bit
+	int32_t vertex3[3]; // libsm64: 32 bit
+    struct {
+        float x;
+        float y;
+        float z;
+    } normal;
+    float originOffset;
+    
+    uint8_t isValid; // libsm64: added field
+    struct SM64SurfaceObjectTransform *transform; // libsm64: added field
+    uint16_t terrain; // libsm64: added field
+};
+
 enum
 {
     SM64_TEXTURE_WIDTH = 64 * 11,
@@ -74,9 +127,8 @@ enum
 typedef void (*SM64DebugPrintFunctionPtr)( const char * );
 extern SM64_LIB_FN void sm64_register_debug_print_function( SM64DebugPrintFunctionPtr debugPrintFunction );
 
-typedef void (*SM64PlaySoundFunctionPtr)( uint32_t soundBits, f32 *pos );
+typedef void (*SM64PlaySoundFunctionPtr)( uint32_t soundBits, float  *pos );
 extern SM64_LIB_FN void sm64_register_play_sound_function( SM64PlaySoundFunctionPtr playSoundFunction );
-
 
 extern SM64_LIB_FN void sm64_global_init( uint8_t *rom, uint8_t *outTexture );
 extern SM64_LIB_FN void sm64_global_terminate( void );
@@ -91,13 +143,13 @@ extern SM64_LIB_FN uint32_t sm64_surface_object_create( const struct SM64Surface
 extern SM64_LIB_FN void sm64_surface_object_move( uint32_t objectId, const struct SM64ObjectTransform *transform );
 extern SM64_LIB_FN void sm64_surface_object_delete( uint32_t objectId );
 
-extern SM64_LIB_FN s32 sm64_surface_find_wall_collision(f32 *xPtr, f32 *yPtr, f32 *zPtr, f32 offsetY, f32 radius);
-extern SM64_LIB_FN s32 sm64_surface_find_wall_collisions(struct WallCollisionData *colData);
-extern SM64_LIB_FN f32 sm64_surface_find_ceil(f32 posX, f32 posY, f32 posZ, struct Surface **pceil);
-extern SM64_LIB_FN f32 sm64_surface_find_floor_height_and_data(f32 xPos, f32 yPos, f32 zPos, struct FloorGeometry **floorGeo);
-extern SM64_LIB_FN f32 sm64_surface_find_floor_height(f32 x, f32 y, f32 z);
-extern SM64_LIB_FN f32 sm64_surface_find_floor(f32 xPos, f32 yPos, f32 zPos, struct Surface **pfloor);
-extern SM64_LIB_FN f32 sm64_surface_find_water_level(f32 x, f32 z);
-extern SM64_LIB_FN f32 sm64_surface_find_poison_gas_level(f32 x, f32 z);
+extern SM64_LIB_FN int32_t sm64_surface_find_wall_collision( float *xPtr, float *yPtr, float *zPtr, float offsetY, float radius );
+extern SM64_LIB_FN int32_t sm64_surface_find_wall_collisions( struct SM64WallCollisionData *colData );
+extern SM64_LIB_FN float sm64_surface_find_ceil( float posX, float posY, float posZ, struct SM64SurfaceCollisionData **pceil );
+extern SM64_LIB_FN float sm64_surface_find_floor_height_and_data( float xPos, float yPos, float zPos, struct SM64FloorCollisionData **floorGeo );
+extern SM64_LIB_FN float sm64_surface_find_floor_height( float x, float y, float z );
+extern SM64_LIB_FN float sm64_surface_find_floor( float xPos, float yPos, float zPos, struct SM64SurfaceCollisionData **pfloor );
+extern SM64_LIB_FN float sm64_surface_find_water_level( float x, float z );
+extern SM64_LIB_FN float sm64_surface_find_poison_gas_level( float x, float z );
 
 #endif//LIB_SM64_H

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "decomp/engine/surface_collision.h"
 #include "decomp/include/types.h"
 
 #ifdef _WIN32
@@ -89,5 +90,14 @@ extern SM64_LIB_FN void sm64_mario_delete( int32_t marioId );
 extern SM64_LIB_FN uint32_t sm64_surface_object_create( const struct SM64SurfaceObject *surfaceObject );
 extern SM64_LIB_FN void sm64_surface_object_move( uint32_t objectId, const struct SM64ObjectTransform *transform );
 extern SM64_LIB_FN void sm64_surface_object_delete( uint32_t objectId );
+
+extern SM64_LIB_FN s32 sm64_surface_find_wall_collision(f32 *xPtr, f32 *yPtr, f32 *zPtr, f32 offsetY, f32 radius);
+extern SM64_LIB_FN s32 sm64_surface_find_wall_collisions(struct WallCollisionData *colData);
+extern SM64_LIB_FN f32 sm64_surface_find_ceil(f32 posX, f32 posY, f32 posZ, struct Surface **pceil);
+extern SM64_LIB_FN f32 sm64_surface_find_floor_height_and_data(f32 xPos, f32 yPos, f32 zPos, struct FloorGeometry **floorGeo);
+extern SM64_LIB_FN f32 sm64_surface_find_floor_height(f32 x, f32 y, f32 z);
+extern SM64_LIB_FN f32 sm64_surface_find_floor(f32 xPos, f32 yPos, f32 zPos, struct Surface **pfloor);
+extern SM64_LIB_FN f32 sm64_surface_find_water_level(f32 x, f32 z);
+extern SM64_LIB_FN f32 sm64_surface_find_poison_gas_level(f32 x, f32 z);
 
 #endif//LIB_SM64_H

--- a/src/load_surfaces.c
+++ b/src/load_surfaces.c
@@ -13,21 +13,21 @@
 
 struct LoadedSurfaceObject
 {
-    struct SurfaceObjectTransform *transform;
+    struct SM64SurfaceObjectTransform *transform;
     uint32_t surfaceCount;
     struct SM64Surface *libSurfaces;
-    struct Surface *engineSurfaces;
+    struct SM64SurfaceCollisionData *engineSurfaces;
 };
 
 static uint32_t s_static_surface_count = 0;
-static struct Surface *s_static_surface_list = NULL;
+static struct SM64SurfaceCollisionData *s_static_surface_list = NULL;
 
 static uint32_t s_surface_object_count = 0;
 static struct LoadedSurfaceObject *s_surface_object_list = NULL;
 
 #define CONVERT_ANGLE( x ) ((s16)( -(x) / 180.0f * 32768.0f ))
 
-static void init_transform( struct SurfaceObjectTransform *out, const struct SM64ObjectTransform *in )
+static void init_transform( struct SM64SurfaceObjectTransform *out, const struct SM64ObjectTransform *in )
 {
     out->aVelX = 0.0f;
     out->aVelY = 0.0f;
@@ -44,7 +44,7 @@ static void init_transform( struct SurfaceObjectTransform *out, const struct SM6
     out->aFaceAngleRoll  = CONVERT_ANGLE(in->eulerRotation[2]);
 }
 
-static void update_transform( struct SurfaceObjectTransform *out, const struct SM64ObjectTransform *in )
+static void update_transform( struct SM64SurfaceObjectTransform *out, const struct SM64ObjectTransform *in )
 {
     out->aVelX = in->position[0] - out->aPosX;
     out->aVelY = in->position[1] - out->aPosY;
@@ -89,7 +89,7 @@ static s32 surface_has_force(s16 surfaceType) {
     return hasForce;
 }
 
-static void engine_surface_from_lib_surface( struct Surface *surface, const struct SM64Surface *libSurf, struct SurfaceObjectTransform *transform )
+static void engine_surface_from_lib_surface( struct SM64SurfaceCollisionData *surface, const struct SM64Surface *libSurf, struct SM64SurfaceObjectTransform *transform )
 {
     int16_t type = libSurf->type;
     int16_t force = libSurf->force;
@@ -221,7 +221,7 @@ uint32_t loaded_surface_iter_group_size( uint32_t groupIndex )
     return s_surface_object_list[ groupIndex - 1 ].surfaceCount;
 }
 
-struct Surface *loaded_surface_iter_get_at_index( uint32_t groupIndex, uint32_t surfaceIndex )
+struct SM64SurfaceCollisionData *loaded_surface_iter_get_at_index( uint32_t groupIndex, uint32_t surfaceIndex )
 {
     if( groupIndex == 0 )
         return &s_static_surface_list[ surfaceIndex ];
@@ -235,7 +235,7 @@ void surfaces_load_static( const struct SM64Surface *surfaceArray, uint32_t numS
         free( s_static_surface_list );
 
     s_static_surface_count = numSurfaces;
-    s_static_surface_list = malloc( sizeof( struct Surface ) * numSurfaces );
+    s_static_surface_list = malloc( sizeof( struct SM64SurfaceCollisionData ) * numSurfaces );
 
     for( int i = 0; i < numSurfaces; ++i )
         engine_surface_from_lib_surface( &s_static_surface_list[i], &surfaceArray[i], NULL );
@@ -267,13 +267,13 @@ uint32_t surfaces_load_object( const struct SM64SurfaceObject *surfaceObject )
 
     obj->surfaceCount = surfaceObject->surfaceCount;
 
-    obj->transform = malloc( sizeof( struct SurfaceObjectTransform ));
+    obj->transform = malloc( sizeof( struct SM64SurfaceObjectTransform ));
     init_transform( obj->transform, &surfaceObject->transform );
 
     obj->libSurfaces = malloc( obj->surfaceCount * sizeof( struct SM64Surface ));
     memcpy( obj->libSurfaces, surfaceObject->surfaces, obj->surfaceCount * sizeof( struct SM64Surface ));
 
-    obj->engineSurfaces = malloc( obj->surfaceCount * sizeof( struct Surface ));
+    obj->engineSurfaces = malloc( obj->surfaceCount * sizeof( struct SM64SurfaceCollisionData ));
     for( int i = 0; i < obj->surfaceCount; ++i )
         engine_surface_from_lib_surface( &obj->engineSurfaces[i], &obj->libSurfaces[i], obj->transform );
 
@@ -314,7 +314,7 @@ void surface_object_update_transform( uint32_t objId, const struct SM64ObjectTra
     }
 }
 
-struct SurfaceObjectTransform *surfaces_object_get_transform_ptr( uint32_t objId )
+struct SM64SurfaceObjectTransform *surfaces_object_get_transform_ptr( uint32_t objId )
 {
     if( objId >= s_surface_object_count || s_surface_object_list[objId].surfaceCount == 0 )
         return NULL;

--- a/src/load_surfaces.h
+++ b/src/load_surfaces.h
@@ -5,11 +5,11 @@
 
 extern uint32_t loaded_surface_iter_group_count( void );
 extern uint32_t loaded_surface_iter_group_size( uint32_t groupIndex );
-extern struct Surface *loaded_surface_iter_get_at_index( uint32_t groupIndex, uint32_t surfaceIndex );
+extern struct SM64SurfaceCollisionData *loaded_surface_iter_get_at_index( uint32_t groupIndex, uint32_t surfaceIndex );
 
 extern void surfaces_load_static( const struct SM64Surface *surfaceArray, uint32_t numSurfaces );
 extern uint32_t surfaces_load_object( const struct SM64SurfaceObject *surfaceObject );
 extern void surface_object_update_transform( uint32_t objId, const struct SM64ObjectTransform *newTransform );
-extern struct SurfaceObjectTransform *surfaces_object_get_transform_ptr( uint32_t objId );
+extern struct SM64SurfaceObjectTransform *surfaces_object_get_transform_ptr( uint32_t objId );
 extern void surfaces_unload_object( uint32_t objId );
 extern void surfaces_unload_all( void );


### PR DESCRIPTION
This PR makes the following changes:

_API changes:_
- raycasting/collision methods from `decomp/engine/surface_collision.h` are now exposed with the prefix `sm64_surface_`

This is useful for exposing SM64's native raycasting/collision logic downstream, where it can be used for custom objects or rendering drop shadows.