### PR TITLE
[FEAT] Add Github Actions Building

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,29 +22,31 @@ jobs:
           sudo apt-get update -y -qq
           sudo apt-get install libsdl2-dev libglew-dev
 
-      - name: Print Folder Structure
-        if: runner.os == 'Linux'
-        run: ls -l
+      #- name: Print Folder Structure
+      #  if: runner.os == 'Linux'
+      #  run: ls -l
 
       - name: Linux - Build Base Binary
         if: runner.os == 'Linux'
-        run: make
-
-      - name: Print Folder Structure
-        if: runner.os == 'Linux'
         run: |
-          ls -l
-          ls -l ./build
-          ls -l ./dist
+          make lib
+          make test
 
-      #- name: Linux - Upload Build
-      #  uses: actions/upload-artifact@v3
+      #- name: Print Folder Structure
       #  if: runner.os == 'Linux'
-      #  with:
-      #    name: sort_cuda
-      #    path: |
-      #      ./dist/libsm64.h
-      #      ./dist/libsm64.so
+      #  run: |
+      #    ls -l
+      #    ls -l ./build
+      #    ls -l ./dist
+
+      - name: Linux - Upload Build
+        uses: actions/upload-artifact@v3
+        if: runner.os == 'Linux'
+        with:
+          name: libsm64
+          path: |
+            ./dist
+            ./build
 
   #Release:
   #  name: "Snapshot Release"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: Build libsm64
 
 on:
+  pull_request:
   push:
     branches: [master]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,29 +22,19 @@ jobs:
           sudo apt-get update -y -qq
           sudo apt-get install libsdl2-dev libglew-dev
 
-      #- name: Print Folder Structure
-      #  if: runner.os == 'Linux'
-      #  run: ls -l
-
       - name: Linux - Build Base Binary
         if: runner.os == 'Linux'
         run: |
           make lib
           make test
 
-      #- name: Print Folder Structure
-      #  if: runner.os == 'Linux'
-      #  run: |
-      #    ls -l
-      #    ls -l ./build
-      #    ls -l ./dist
-
       - name: Linux - Upload Build
         uses: actions/upload-artifact@v3
         if: runner.os == 'Linux'
         with:
-          name: libsm64
+          name: libsm64_linux
           path: |
+            ./README.md
             ./dist
             ./build
 
@@ -65,5 +55,6 @@ jobs:
   #        prerelease: true
   #        title: "Snapshot Build"
   #        files: |
-  #          /home/runner/work/sort_cuda/sort_cuda/sort_std
-  #          /home/runner/work/sort_cuda/sort_cuda/sort_cuda
+  #         ./README.md
+  #         ./dist
+  #         ./build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,67 @@
+name: Build libsm64
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install SDL2 and GLEW
+        if: runner.os == 'Linux'
+        run: |
+          sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe restricted multiverse"
+          sudo apt-get update -y -qq
+          sudo apt-get install libsdl2-dev libglew-dev
+
+      - name: Print Folder Structure
+        if: runner.os == 'Linux'
+        run: ls -l
+
+      - name: Linux - Build Base Binary
+        if: runner.os == 'Linux'
+        run: make
+
+      - name: Print Folder Structure
+        if: runner.os == 'Linux'
+        run: |
+          ls -l
+          ls -l ./build
+          ls -l ./dist
+
+      #- name: Linux - Upload Build
+      #  uses: actions/upload-artifact@v3
+      #  if: runner.os == 'Linux'
+      #  with:
+      #    name: sort_cuda
+      #    path: |
+      #      ./dist/libsm64.h
+      #      ./dist/libsm64.so
+
+  #Release:
+  #  name: "Snapshot Release"
+  #  runs-on: "ubuntu-latest"
+  #  needs: Build
+
+  #  steps:
+  #    - name: Download artifacts
+  #      uses: actions/download-artifact@v3
+
+  #    - name: Create a Release
+  #      uses: "marvinpinto/action-automatic-releases@latest"
+  #      with:
+  #        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+  #        automatic_release_tag: "latest"
+  #        prerelease: true
+  #        title: "Snapshot Build"
+  #        files: |
+  #          /home/runner/work/sort_cuda/sort_cuda/sort_std
+  #          /home/runner/work/sort_cuda/sort_cuda/sort_cuda


### PR DESCRIPTION
@jaburns 

This PR adds basic Github Actions building for the library and test program on Linux.

Future PRs may add support for Windows and Emscripten compilation.

Commented out automatic release creation is included for the brave of heart.

See Example Build Jobs here: https://github.com/zalo/libsm64/actions?query=branch%3Amaster