### PR TITLE
Avoid crash in mario_delete if audio not init

### DIFF
--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -146,7 +146,7 @@ SM64_LIB_FN void sm64_audio_init( uint8_t *rom ) {
 #define SAMPLES_LOW 528
 
 extern SM64_LIB_FN uint32_t sm64_audio_tick( uint32_t numQueuedSamples, uint32_t numDesiredSamples, int16_t *audio_buffer ) {
-    if ( !is_audio_initialized ) {
+    if ( !g_is_audio_initialized ) {
         DEBUG_PRINT("Attempted to tick audio, but sm64_audio_init() has not been called yet.");
         return 0;
     }
@@ -271,7 +271,7 @@ SM64_LIB_FN void sm64_mario_delete( int32_t marioId )
     struct GlobalState *globalState = ((struct MarioInstance *)s_mario_instance_pool.objects[ marioId ])->globalState;
     global_state_bind( globalState );
 
-    if ( is_audio_initialized ) {
+    if ( g_is_audio_initialized ) {
         stop_sound(SOUND_MARIO_SNORING3, gMarioState->marioObj->header.gfx.cameraToObject);
     }
 

--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -150,9 +150,9 @@ extern SM64_LIB_FN uint32_t sm64_audio_tick( uint32_t numQueuedSamples, uint32_t
         DEBUG_PRINT("Attempted to tick audio, but sm64_audio_init() has not been called yet.");
         return 0;
     }
-    
+
     update_game_sound();
-	
+
     u32 num_audio_samples = numQueuedSamples < numDesiredSamples ? SAMPLES_HIGH : SAMPLES_LOW;
     for (int i = 0; i < 2; i++)
     {
@@ -271,7 +271,9 @@ SM64_LIB_FN void sm64_mario_delete( int32_t marioId )
     struct GlobalState *globalState = ((struct MarioInstance *)s_mario_instance_pool.objects[ marioId ])->globalState;
     global_state_bind( globalState );
 
-    stop_sound(SOUND_MARIO_SNORING3, gMarioState->marioObj->header.gfx.cameraToObject);
+    if ( is_audio_initialized ) {
+        stop_sound(SOUND_MARIO_SNORING3, gMarioState->marioObj->header.gfx.cameraToObject);
+    }
 
     free( gMarioObject );
     free_area( gCurrentArea );
@@ -592,7 +594,7 @@ SM64_LIB_FN void sm64_surface_object_delete( uint32_t objectId )
 }
 
 
-SM64_LIB_FN int32_t sm64_surface_find_wall_collision( float *xPtr, float *yPtr, float *zPtr, float offsetY, float radius ) 
+SM64_LIB_FN int32_t sm64_surface_find_wall_collision( float *xPtr, float *yPtr, float *zPtr, float offsetY, float radius )
 {
     return f32_find_wall_collision( xPtr, yPtr, zPtr, offsetY, radius );
 }

--- a/src/load_audio_data.c
+++ b/src/load_audio_data.c
@@ -4,7 +4,7 @@
 #include "decomp/audio/load.h"
 #include "decomp/audio/load_dat.h"
 
-bool is_audio_initialized = false;
+bool g_is_audio_initialized = false;
 
 extern void load_audio_banks( uint8_t *rom ) {
     uint8_t *rom2 = malloc( 0x800000 );
@@ -19,9 +19,9 @@ extern void load_audio_banks( uint8_t *rom ) {
     gBankSetsData[0x45]=0x00;
     ptrs_to_offsets( gSoundDataADSR );
 
-    audio_init();  
+    audio_init();
     sound_init();
     sound_reset( 0 );
-    
-    is_audio_initialized = true;
+
+    g_is_audio_initialized = true;
 }

--- a/src/load_audio_data.h
+++ b/src/load_audio_data.h
@@ -3,6 +3,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-extern bool is_audio_initialized;
+extern bool g_is_audio_initialized;
 
 extern void load_audio_banks( uint8_t *rom );

--- a/src/play_sound.c
+++ b/src/play_sound.c
@@ -7,7 +7,7 @@
 SM64PlaySoundFunctionPtr g_play_sound_func = NULL;
 
 extern void play_sound( uint32_t soundBits, f32 *pos ) {
-    if ( is_audio_initialized ) {
+    if ( g_is_audio_initialized ) {
         DEBUG_PRINT("$ play_sound(%d) request %d; pos %f %f %f\n", soundBits,sSoundRequestCount,pos[0],pos[1],pos[2]);
         sSoundRequests[sSoundRequestCount].soundBits = soundBits;
         sSoundRequests[sSoundRequestCount].position = pos;


### PR DESCRIPTION
Calling `sm64_mario_delete` without audio being init crashes because of the `stop_sound` call, this fixes it.