### PR TITLE
Make the received rom buffer const

### DIFF
--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -96,7 +96,7 @@ SM64_LIB_FN void sm64_register_play_sound_function( SM64PlaySoundFunctionPtr pla
 }
 
 
-SM64_LIB_FN void sm64_global_init( uint8_t *rom, uint8_t *outTexture )
+SM64_LIB_FN void sm64_global_init( const uint8_t *rom, uint8_t *outTexture )
 {
     if( s_init_global )
         sm64_global_terminate();
@@ -138,7 +138,7 @@ SM64_LIB_FN void sm64_global_terminate( void )
     memory_terminate();
 }
 
-SM64_LIB_FN void sm64_audio_init( uint8_t *rom ) {
+SM64_LIB_FN void sm64_audio_init( const uint8_t *rom ) {
     load_audio_banks( rom );
 }
 
@@ -150,9 +150,9 @@ extern SM64_LIB_FN uint32_t sm64_audio_tick( uint32_t numQueuedSamples, uint32_t
         DEBUG_PRINT("Attempted to tick audio, but sm64_audio_init() has not been called yet.");
         return 0;
     }
-    
+
     update_game_sound();
-	
+
     u32 num_audio_samples = numQueuedSamples < numDesiredSamples ? SAMPLES_HIGH : SAMPLES_LOW;
     for (int i = 0; i < 2; i++)
     {
@@ -592,7 +592,7 @@ SM64_LIB_FN void sm64_surface_object_delete( uint32_t objectId )
 }
 
 
-SM64_LIB_FN int32_t sm64_surface_find_wall_collision( float *xPtr, float *yPtr, float *zPtr, float offsetY, float radius ) 
+SM64_LIB_FN int32_t sm64_surface_find_wall_collision( float *xPtr, float *yPtr, float *zPtr, float offsetY, float radius )
 {
     return f32_find_wall_collision( xPtr, yPtr, zPtr, offsetY, radius );
 }

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -114,7 +114,7 @@ struct SM64SurfaceCollisionData
         float z;
     } normal;
     float originOffset;
-    
+
     uint8_t isValid; // libsm64: added field
     struct SM64SurfaceObjectTransform *transform; // libsm64: added field
     uint16_t terrain; // libsm64: added field
@@ -134,10 +134,10 @@ extern SM64_LIB_FN void sm64_register_debug_print_function( SM64DebugPrintFuncti
 typedef void (*SM64PlaySoundFunctionPtr)( uint32_t soundBits, float *pos );
 extern SM64_LIB_FN void sm64_register_play_sound_function( SM64PlaySoundFunctionPtr playSoundFunction );
 
-extern SM64_LIB_FN void sm64_global_init( uint8_t *rom, uint8_t *outTexture );
+extern SM64_LIB_FN void sm64_global_init( const uint8_t *rom, uint8_t *outTexture );
 extern SM64_LIB_FN void sm64_global_terminate( void );
 
-extern SM64_LIB_FN void sm64_audio_init( uint8_t *rom  );
+extern SM64_LIB_FN void sm64_audio_init( const uint8_t *rom );
 extern SM64_LIB_FN uint32_t sm64_audio_tick( uint32_t numQueuedSamples, uint32_t numDesiredSamples, int16_t *audio_buffer );
 
 extern SM64_LIB_FN void sm64_static_surfaces_load( const struct SM64Surface *surfaceArray, uint32_t numSurfaces );

--- a/src/load_anim_data.c
+++ b/src/load_anim_data.c
@@ -7,20 +7,20 @@ static struct Animation *s_libsm64_mario_animations = NULL;
 
 #define ANIM_DATA_ADDRESS 0x004EC000
 
-static uint16_t read_u16_be( uint8_t *p )
+static uint16_t read_u16_be( const uint8_t *p )
 {
-    return 
+    return
         (uint32_t)p[0] << 8 |
         (uint32_t)p[1];
 
 }
 
-static uint16_t read_s16_be( uint8_t *p )
+static uint16_t read_s16_be( const uint8_t *p )
 {
     return (int16_t)read_u16_be( p );
 }
 
-static uint32_t read_u32_be( uint8_t *p )
+static uint32_t read_u32_be( const uint8_t *p )
 {
     return
         (uint32_t)p[0] << 24 |
@@ -29,12 +29,12 @@ static uint32_t read_u32_be( uint8_t *p )
         (uint32_t)p[3];
 }
 
-void load_mario_anims_from_rom( uint8_t *rom )
+void load_mario_anims_from_rom( const uint8_t *rom )
 {
     #define GET_OFFSET( n ) (read_u32_be((uint8_t*)&((struct OffsetSizePair*)( rom + ANIM_DATA_ADDRESS + 8 + (n)*8 ))->offset))
     #define GET_SIZE(   n ) (read_u32_be((uint8_t*)&((struct OffsetSizePair*)( rom + ANIM_DATA_ADDRESS + 8 + (n)*8 ))->size  ))
 
-    uint8_t *read_ptr = rom + ANIM_DATA_ADDRESS;
+    const uint8_t *read_ptr = rom + ANIM_DATA_ADDRESS;
     s_num_entries = read_u32_be( read_ptr );
 
     s_libsm64_mario_animations = malloc( s_num_entries * sizeof( struct Animation ));
@@ -54,9 +54,9 @@ void load_mario_anims_from_rom( uint8_t *rom )
         uint32_t index_offset  = read_u32_be( read_ptr ); read_ptr += 4;
         uint32_t end_offset    = read_u32_be( read_ptr );
 
-        read_ptr            = rom + ANIM_DATA_ADDRESS + GET_OFFSET(i) + index_offset;
-        uint8_t *values_ptr = rom + ANIM_DATA_ADDRESS + GET_OFFSET(i) + values_offset;
-        uint8_t *end_ptr    = rom + ANIM_DATA_ADDRESS + GET_OFFSET(i) + end_offset;
+        read_ptr                  = rom + ANIM_DATA_ADDRESS + GET_OFFSET(i) + index_offset;
+        const uint8_t *values_ptr = rom + ANIM_DATA_ADDRESS + GET_OFFSET(i) + values_offset;
+        const uint8_t *end_ptr    = rom + ANIM_DATA_ADDRESS + GET_OFFSET(i) + end_offset;
 
         anims[i].index = malloc( values_offset - index_offset );
         anims[i].values = malloc( end_offset - values_offset );

--- a/src/load_anim_data.h
+++ b/src/load_anim_data.h
@@ -6,5 +6,5 @@
 #include "decomp/include/types.h"
 
 extern void load_mario_animation(struct MarioAnimation *a, u32 index);
-extern void load_mario_anims_from_rom( uint8_t *rom );
+extern void load_mario_anims_from_rom( const uint8_t *rom );
 extern void unload_mario_anims( void );

--- a/src/load_audio_data.c
+++ b/src/load_audio_data.c
@@ -6,22 +6,23 @@
 
 bool is_audio_initialized = false;
 
-extern void load_audio_banks( uint8_t *rom ) {
-    uint8_t *rom2 = malloc( 0x800000 );
+extern void load_audio_banks( const uint8_t *rom ) {
+    // FIXME: rom_copy purposfully leaks here
+    uint8_t *rom_copy = malloc( 0x800000 );
 
-    memcpy( rom2, rom, 0x800000 );
-    rom = rom2;
-    gSoundDataADSR = parse_seqfile( rom+0x57B720 ); //ctl
-    gSoundDataRaw = parse_seqfile( rom+0x593560 ); //tbl
-    gMusicData = parse_seqfile( rom+0x7B0860 );
-    gBankSetsData = rom+0x7CC621;
+    memcpy( rom_copy, rom, 0x800000 );
+
+    gSoundDataADSR = parse_seqfile( rom_copy+0x57B720 ); //ctl
+    gSoundDataRaw = parse_seqfile( rom_copy+0x593560 ); //tbl
+    gMusicData = parse_seqfile( rom_copy+0x7B0860 );
+    gBankSetsData = rom_copy+0x7CC621;
     memmove( gBankSetsData+0x45,gBankSetsData+0x45-1,0x5B );
     gBankSetsData[0x45]=0x00;
     ptrs_to_offsets( gSoundDataADSR );
 
-    audio_init();  
+    audio_init();
     sound_init();
     sound_reset( 0 );
-    
+
     is_audio_initialized = true;
 }

--- a/src/load_audio_data.h
+++ b/src/load_audio_data.h
@@ -5,4 +5,4 @@
 
 extern bool is_audio_initialized;
 
-extern void load_audio_banks( uint8_t *rom );
+extern void load_audio_banks( const uint8_t *rom );

--- a/src/load_tex_data.c
+++ b/src/load_tex_data.c
@@ -26,12 +26,12 @@ static void blt_image_to_atlas( rgba *img, int i, int w, int h, uint8_t *outText
     }
 }
 
-void load_mario_textures_from_rom( uint8_t *rom, uint8_t *outTexture )
+void load_mario_textures_from_rom( const uint8_t *rom, uint8_t *outTexture )
 {
     memset( outTexture, 0, 4 * ATLAS_WIDTH * ATLAS_HEIGHT );
 
     mio0_header_t head;
-    uint8_t *in_buf = rom + MARIO_TEX_ROM_OFFSET;
+    const uint8_t *in_buf = rom + MARIO_TEX_ROM_OFFSET;
 
     mio0_decode_header( in_buf, &head );
     uint8_t *out_buf = malloc( head.dest_size );

--- a/src/load_tex_data.h
+++ b/src/load_tex_data.h
@@ -31,4 +31,4 @@ static const int mario_tex_offsets[NUM_USED_TEXTURES] = { 144, 4240, 6288, 8336,
 static const int mario_tex_widths [NUM_USED_TEXTURES] = { 64, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32 };
 static const int mario_tex_heights[NUM_USED_TEXTURES] = { 32, 32, 32, 32, 32, 32, 32, 32, 32, 64, 64 };
 
-extern void load_mario_textures_from_rom( uint8_t *rom, uint8_t *outTexture );
+extern void load_mario_textures_from_rom( const uint8_t *rom, uint8_t *outTexture );


### PR DESCRIPTION
The `sm64_global_init` and `sm64_audio_init` functions don't (and shouldn't) need the passed ROM buffer to be mutable, so it's better to make it const. This change is fully API and ABI retro compatible.