### PR TITLE
Fixed inverted controls when airborne

### DIFF
--- a/src/decomp/game/mario_actions_airborne.c
+++ b/src/decomp/game/mario_actions_airborne.c
@@ -277,7 +277,7 @@ void update_lava_boost_or_twirling(struct MarioState *m) {
 }
 
 void update_flying_yaw(struct MarioState *m) {
-    s16 targetYawVel = -(s16)(m->controller->stickX * (m->forwardVel / 4.0f));
+    s16 targetYawVel = (s16)(m->controller->stickX * (m->forwardVel / 4.0f));
 
     if (targetYawVel > 0) {
         if (m->angleVel[1] < 0) {
@@ -306,7 +306,7 @@ void update_flying_yaw(struct MarioState *m) {
 }
 
 void update_flying_pitch(struct MarioState *m) {
-    s16 targetPitchVel = -(s16)(m->controller->stickY * (m->forwardVel / 5.0f));
+    s16 targetPitchVel = (s16)(m->controller->stickY * (m->forwardVel / 5.0f));
 
     if (targetPitchVel > 0) {
         if (m->angleVel[0] < 0) {


### PR DESCRIPTION
It seems the controls are inverted when flying using the wing cap.

The left button makes Mario go right, and the right makes Mario go left.
The vertical inputs also seem swapped, when I press up I'm pretty sure it should go down, and when press down it should go up.

I'm unsure if this is the way to fix it. But it seemed to work for me. (Note: I don't know what I'm doing)

I tested by adding `sm64_mario_interact_cap(marioId, 0x00000008, 60000, 1);` to the `main.cpp` after the `sm64_play_music`
And then use the test build: `make run` (should trigger the mario wing cap for a long time).

I'm having a blast using this lib, thanks a lot for the efforts!