### PR TITLE
Only export lib functions in linux builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ else
   CXX     := c++
   LDFLAGS := -lm -shared
 endif
-CFLAGS := -g -Wall -Wno-unused-function -fPIC -DSM64_LIB_EXPORT -DGBI_FLOATS -DVERSION_US -DNO_SEGMENTED_MEMORY
+CFLAGS := -g -Wall -Wno-unused-function -fPIC -fvisibility=hidden -DSM64_LIB_EXPORT -DGBI_FLOATS -DVERSION_US -DNO_SEGMENTED_MEMORY
 
 SRC_DIRS  := src src/decomp src/decomp/engine src/decomp/include/PR src/decomp/game src/decomp/pc src/decomp/pc/audio src/decomp/mario src/decomp/tools src/decomp/audio
 BUILD_DIR := build

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -5,12 +5,14 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifdef _WIN32
+#if defined(_WIN32)
     #ifdef SM64_LIB_EXPORT
         #define SM64_LIB_FN __declspec(dllexport)
     #else
         #define SM64_LIB_FN __declspec(dllimport)
     #endif
+#elif defined(__GNUC__) && __GNUC__ >= 4
+    #define SM64_LIB_FN __attribute__ ((visibility("default")))
 #else
     #define SM64_LIB_FN
 #endif


### PR DESCRIPTION
Just like how Windows does by default, only export the library symbols on the Linux build. Technically raises the GCC requirements to at least version 4.

For reference, after this change the generated shared library ended up being over 100kb smaller and exports only 49 symbols as opposed to 993 (!) symbols.