### PR TITLE
Fix compilation order dependency for generated level.c file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,10 @@ $(LIB_FILE): $(O_FILES)
 $(LIB_H_FILE): src/libsm64.h
 	cp -f $< $@
 
-
-test/level.c test/level.h: ./import-test-collision.py
+test/level.c: ./import-test-collision.py
 	./import-test-collision.py
 
-test/main.cpp: test/level.h
+test/main.cpp test/gl20/gl20_renderer.c test/gl33core/gl33core_renderer.c: test/level.c
 
 $(BUILD_DIR)/test/%.o: test/%.c
 	@$(CC) $(CFLAGS) -MM -MP -MT $@ -MF $(BUILD_DIR)/test/$*.d $<


### PR DESCRIPTION
I noticed in the github build action triggered in #57 that the compilation of the test target can fail if `gl20_renderer.c` or `gl33core_renderer.c` are compiled before `import-test-collision.py` has been run to completion. This PR enforces this dependency in order to avoid failure in parallel builds.