### PR TITLE
Add support for macOS and Emscripten builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,11 @@ src/decomp/mario/geo.inc.c: ./import-mario-geo.py
 	./import-mario-geo.py
 
 $(BUILD_DIR)/%.o: %.c $(IMPORTED)
-	@$(CC) $(CFLAGS) -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
+	@$(CC) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
 	$(CC) -c $(CFLAGS) -I src/decomp/include -o $@ $<
 
 $(BUILD_DIR)/%.o: %.cpp $(IMPORTED)
-	@$(CXX) $(CFLAGS) -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
+	@$(CXX) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
 	$(CXX) -c $(CFLAGS) -I src/decomp/include -o $@ $<
 
 $(LIB_FILE): $(O_FILES)

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,8 @@ $(BUILD_DIR)/test/%.o: test/%.c
 $(TEST_FILE): $(LIB_FILE) $(TEST_OBJS)
 ifeq ($(OS),Windows_NT)
 	$(CC) -o $@ $(TEST_OBJS) $(LIB_FILE) -lglew32 -lopengl32 -lSDL2 -lSDL2main -lm
+else ifeq ($(shell uname -s),Darwin)
+	$(CC) -o $@ $(TEST_OBJS) $(LIB_FILE) -framework OpenGL -lGLEW -lSDL2 -lSDL2main -lm -lpthread
 else
 	$(CC) -o $@ $(TEST_OBJS) $(LIB_FILE) -lGLEW -lGL -lSDL2 -lSDL2main -lm -lpthread
 endif

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ifeq ($(OS),Windows_NT)
   TEST_FILE := $(DIST_DIR)/run-test.exe
 endif
 
-DUMMY != mkdir -p $(ALL_DIRS) build/test build/test/gl33core build/test/gl20 src/decomp/mario $(DIST_DIR)/include
+DUMMY := $(shell mkdir -p $(ALL_DIRS) build/test build/test/gl33core build/test/gl20 src/decomp/mario $(DIST_DIR)/include)
 
 
 $(filter-out src/decomp/mario/geo.inc.c,$(IMPORTED)): src/decomp/mario/geo.inc.c

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ project under the `test` directory as well, demonstrating usage of the library.
 - Run `make` to build
 - To run the test program you'll need a SM64 US ROM in the root of the repository with the name `baserom.us.z64`.
 
+## Building for Emscripten (Web) (WIP)
+
+Run `emmake make CC=emcc`.
+
+If you want libsm64 standalone to call from JS (may not be that
+useful?), then run `emcc dist/libsm64.so -o libsm64.js` afterward to
+emit `libsm64.wasm` and `libsm64.js`.
+
+Otherwise, `dist/libsm64.so` should be a compiled WebAssembly object
+that you can link into your own C project.
+
 ## Make targets (all platforms)
 
 - `make lib`: (Default) Build the `dist` directory, containing the shared object or DLL and public-facing header.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ project under the `test` directory as well, demonstrating usage of the library.
 - [Godot add-on](https://github.com/Brawmario/libsm64-godot)
 - [Game Maker 8 extension](https://github.com/headshot2017/libsm64-gm8)
 
-## Building on Linux
+## Building on Mac and Linux
 
 - Ensure python3 is installed.
 - Ensure the SDL2 and GLEW libraries are installed if you're building the test program (on Ubuntu: libsdl2-dev, libglew-dev).

--- a/src/decomp/game/mario.c
+++ b/src/decomp/game/mario.c
@@ -35,7 +35,7 @@
 // #include "object_list_processor.h"
 // #include "print.h"
 #include "save_file.h"
-// #include "sound_init.h"
+#include "sound_init.h"
 // #include "thread6.h"
 #include "../../load_anim_data.h"
 

--- a/src/decomp/game/sound_init.c
+++ b/src/decomp/game/sound_init.c
@@ -14,6 +14,7 @@
 #include <seq_ids.h>
 #include <sm64.h>
 #include "sound_init.h"
+#include "../../play_sound.h"
 //#include "rumble_init.h"
 
 #define MUSIC_NONE 0xFFFF

--- a/src/decomp/include/PR/os_libc.h
+++ b/src/decomp/include/PR/os_libc.h
@@ -3,8 +3,13 @@
 
 #include "ultratypes.h"
 
+// These are defined in macOS (BSD?), so we want to def them out.
+#ifndef __APPLE__
+
 // Old deprecated functions from strings.h, replaced by memcpy/memset.
 extern void bcopy(const void *, void *, size_t);
 extern void bzero(void *, size_t);
+
+#endif
 
 #endif /* !_OS_LIBC_H_ */

--- a/src/decomp/tools/convUtils.c
+++ b/src/decomp/tools/convUtils.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>
+#include <string.h>
 #include "convUtils.h"
 #include "convTypes.h"
 

--- a/src/load_audio_data.c
+++ b/src/load_audio_data.c
@@ -1,8 +1,11 @@
 #include "load_audio_data.h"
 
 #include "decomp/tools/convUtils.h"
+#include "decomp/audio/external.h"
 #include "decomp/audio/load.h"
 #include "decomp/audio/load_dat.h"
+
+#include <string.h>
 
 bool g_is_audio_initialized = false;
 

--- a/test/gl20/gl20_renderer.c
+++ b/test/gl20/gl20_renderer.c
@@ -1,5 +1,6 @@
 #include "gl20_renderer.h"
 
+#include <OpenGL/gl.h>
 #include <stdio.h>
 
 #include "../../src/libsm64.h"

--- a/test/gl20/gl20_renderer.c
+++ b/test/gl20/gl20_renderer.c
@@ -1,6 +1,9 @@
 #include "gl20_renderer.h"
 
+#ifdef __APPLE__
 #include <OpenGL/gl.h>
+#endif
+
 #include <stdio.h>
 
 #include "../../src/libsm64.h"


### PR DESCRIPTION
On macOS, everything seems to work, including the test app:

<img width="912" alt="A0D04B79-3F02-47FD-AA04-1D3A83573355-1330-00000AA5E0E738DA" src="https://github.com/libsm64/libsm64/assets/96857/638b192a-5be7-4a82-b144-c3264984ce8e">

On Emscripten, I didn't port/try the test app yet, but the library compiles and links into a Web app and can load the ROM and fill the texture with no problems; haven't tested more than that. Hopefully fixes #48.

I also tested Linux build of library & test app and that still works. Didn't get to test Windows.

I think these changes are mostly slight clang differences with include and cast requirements and macOS make/include path differences.