### PR TITLE
macOS: compile universal binaries (x86_64 and arm64)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ else
   LDFLAGS := -lm -shared
 endif
 CFLAGS := -fno-strict-aliasing -g -Wall -Wno-unused-function -fPIC -fvisibility=hidden -DSM64_LIB_EXPORT -DGBI_FLOATS -DVERSION_US -DNO_SEGMENTED_MEMORY
+ifeq ($(shell uname -s),Darwin)
+  CFLAGS += -arch x86_64 -arch arm64
+  LDFLAGS += -arch x86_64 -arch arm64
+endif
 
 SRC_DIRS  := src src/decomp src/decomp/engine src/decomp/include/PR src/decomp/game src/decomp/pc src/decomp/pc/audio src/decomp/mario src/decomp/tools src/decomp/audio
 BUILD_DIR := build

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ $(BUILD_DIR)/%_arm64.o: %.cpp $(IMPORTED)
 
 $(LIB_FILE): $(OBJS_x86_64) $(OBJS_arm64)
 	$(CC) $(LDFLAGS) -arch arm64 -o $@.arm64 $(OBJS_arm64)
-	$(CC) $(LDFLAGS) -arch arm64 -o $@.x86_64 $(OBJS_x86_64)
+	$(CC) $(LDFLAGS) -arch x86_64 -o $@.x86_64 $(OBJS_x86_64)
 	lipo -create -output $@ arm64$@ x86_64$@
 
 else

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ default: lib
 
 ifeq ($(shell uname -s),Darwin)
   MACOS_BUILD = 1
+else ifeq ($(OS),Windows_NT)
+  WINDOWS_BUILD = 1
 endif
 
 ifdef LIBSM64_MUSL
@@ -28,21 +30,21 @@ C_IMPORTED := src/decomp/mario/geo.inc.c src/decomp/mario/model.inc.c
 H_IMPORTED := $(C_IMPORTED:.c=.h)
 IMPORTED   := $(C_IMPORTED) $(H_IMPORTED)
 
-C_FILES   := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c)) $(C_IMPORTED)
+C_FILES := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c)) $(C_IMPORTED)
 ifdef MACOS_BUILD
-  OBJS_x86_64 := $(foreach file,$(C_FILES),$(BUILD_DIR)/$(file:.c=_x86_64.o))
-  OBJS_arm64 := $(foreach file,$(C_FILES),$(BUILD_DIR)/$(file:.c=_arm64.o))
-  DEP_FILES := $(OBJS_x86_64:.o=.d) $(OBJS_arm64:.o=.d)
+  O_FILES_x86_64 := $(foreach file,$(C_FILES),$(BUILD_DIR)/$(file:.c=_x86_64.o))
+  O_FILES_arm64  := $(foreach file,$(C_FILES),$(BUILD_DIR)/$(file:.c=_arm64.o))
+  DEP_FILES      := $(O_FILES_x86_64:.o=.d) $(O_FILES_arm64:.o=.d)
 else
-  O_FILES   := $(foreach file,$(C_FILES),$(BUILD_DIR)/$(file:.c=.o))
-  DEP_FILES := $(O_FILES:.o=.d)
+  O_FILES        := $(foreach file,$(C_FILES),$(BUILD_DIR)/$(file:.c=.o))
+  DEP_FILES      := $(O_FILES:.o=.d)
 endif
 
 TEST_SRCS_C   := test/context.c test/level.c test/gl33core/gl33core_renderer.c test/gl20/gl20_renderer.c
 TEST_SRCS_CPP := test/main.cpp test/audio.cpp
 TEST_OBJS     := $(foreach file,$(TEST_SRCS_C),$(BUILD_DIR)/$(file:.c=.o)) $(foreach file,$(TEST_SRCS_CPP),$(BUILD_DIR)/$(file:.cpp=.o))
 
-ifeq ($(OS),Windows_NT)
+ifdef WINDOWS_BUILD
   LIB_FILE := $(DIST_DIR)/sm64.dll
   TEST_FILE := $(DIST_DIR)/run-test.exe
 else ifdef MACOS_BUILD
@@ -50,7 +52,6 @@ else ifdef MACOS_BUILD
 endif
 
 DUMMY := $(shell mkdir -p $(ALL_DIRS) build/test build/test/gl33core build/test/gl20 src/decomp/mario $(DIST_DIR)/include)
-
 
 $(filter-out src/decomp/mario/geo.inc.c,$(IMPORTED)): src/decomp/mario/geo.inc.c
 src/decomp/mario/geo.inc.c: ./import-mario-geo.py
@@ -66,21 +67,19 @@ $(BUILD_DIR)/%_arm64.o: %.c $(IMPORTED)
 	$(CC) -c $(CFLAGS) -arch arm64 -I src/decomp/include -o $@ $<
 
 $(BUILD_DIR)/%_x86_64.o: %.cpp $(IMPORTED)
-	@$(CC) $(CFLAGS) -arch x86_64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_x86_64.d $<
-	$(CC) -c $(CFLAGS) -arch x86_64 -I src/decomp/include -o $@ $<
+	@$(CXX) $(CFLAGS) -arch x86_64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_x86_64.d $<
+	$(CXX) -c $(CFLAGS) -arch x86_64 -I src/decomp/include -o $@ $<
 
 $(BUILD_DIR)/%_arm64.o: %.cpp $(IMPORTED)
 	@$(CXX) $(CFLAGS) -arch arm64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_arm64.d $<
 	$(CXX) -c $(CFLAGS) -arch arm64 -I src/decomp/include -o $@ $<
 
-$(LIB_FILE): $(OBJS_x86_64) $(OBJS_arm64)
-	$(CC) $(LDFLAGS) -arch arm64 -o $@.arm64 $(OBJS_arm64)
-	$(CC) $(LDFLAGS) -arch x86_64 -o $@.x86_64 $(OBJS_x86_64)
+$(LIB_FILE): $(O_FILES_x86_64) $(O_FILES_arm64)
+	$(CC) $(LDFLAGS) -arch arm64 -o $@.arm64 $(O_FILES_arm64)
+	$(CC) $(LDFLAGS) -arch x86_64 -o $@.x86_64 $(O_FILES_x86_64)
 	lipo -create -output $@ $@.arm64 $@.x86_64
 	rm $@.arm64 $@.x86_64
-
 else
-
 $(BUILD_DIR)/%.o: %.c $(IMPORTED)
 	@$(CC) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
 	$(CC) -c $(CFLAGS) -I src/decomp/include -o $@ $<
@@ -106,7 +105,7 @@ $(BUILD_DIR)/test/%.o: test/%.c
 	$(CC) -c $(CFLAGS) -o $@ $<
 
 $(TEST_FILE): $(LIB_FILE) $(TEST_OBJS)
-ifeq ($(OS),Windows_NT)
+ifdef WINDOWS_BUILD
 	$(CC) -o $@ $(TEST_OBJS) $(LIB_FILE) -lglew32 -lopengl32 -lSDL2 -lSDL2main -lm
 else ifdef MACOS_BUILD
 	$(CC) -o $@ $(TEST_OBJS) $(LIB_FILE) -framework OpenGL -lGLEW -lSDL2 -lSDL2main -lm -lpthread
@@ -119,7 +118,7 @@ lib: $(LIB_FILE) $(LIB_H_FILE)
 test: $(TEST_FILE) $(LIB_H_FILE)
 
 run: test
-ifeq ($(OS),Windows_NT)
+ifdef WINDOWS_BUILD
 	cd dist && ./run-test
 else
 	./$(TEST_FILE)

--- a/Makefile
+++ b/Makefile
@@ -54,19 +54,19 @@ src/decomp/mario/geo.inc.c: ./import-mario-geo.py
 
 ifeq ($(shell uname -s),Darwin)
 $(BUILD_DIR)/%_x86_64.o: %.c $(IMPORTED)
-#	@$(CC) $(CFLAGS) -arch x86_64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_x86_64.d $<
+	@$(CC) $(CFLAGS) -arch x86_64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_x86_64.d $<
 	$(CC) -c $(CFLAGS) -arch x86_64 -I src/decomp/include -o $@ $<
 
 $(BUILD_DIR)/%_arm64.o: %.c $(IMPORTED)
-#	@$(CC) $(CFLAGS) -arch arm64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_arm64.d $<
+	@$(CC) $(CFLAGS) -arch arm64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_arm64.d $<
 	$(CC) -c $(CFLAGS) -arch arm64 -I src/decomp/include -o $@ $<
 
 $(BUILD_DIR)/%_x86_64.o: %.cpp $(IMPORTED)
-#	@$(CC) $(CFLAGS) -arch x86_64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_x86_64.d $<
+	@$(CC) $(CFLAGS) -arch x86_64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_x86_64.d $<
 	$(CC) -c $(CFLAGS) -arch x86_64 -I src/decomp/include -o $@ $<
 
 $(BUILD_DIR)/%_arm64.o: %.cpp $(IMPORTED)
-#	@$(CXX) $(CFLAGS) -arch arm64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_arm64.d $<
+	@$(CXX) $(CFLAGS) -arch arm64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_arm64.d $<
 	$(CXX) -c $(CFLAGS) -arch arm64 -I src/decomp/include -o $@ $<
 
 $(LIB_FILE): $(OBJS_x86_64) $(OBJS_arm64)
@@ -77,11 +77,11 @@ $(LIB_FILE): $(OBJS_x86_64) $(OBJS_arm64)
 else
 
 $(BUILD_DIR)/%.o: %.c $(IMPORTED)
-#	@$(CC) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
+	@$(CC) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
 	$(CC) -c $(CFLAGS) -I src/decomp/include -o $@ $<
 
 $(BUILD_DIR)/%.o: %.cpp $(IMPORTED)
-#	@$(CXX) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
+	@$(CXX) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
 	$(CXX) -c $(CFLAGS) -I src/decomp/include -o $@ $<
 
 $(LIB_FILE): $(O_FILES)
@@ -123,4 +123,4 @@ endif
 clean:
 	rm -rf $(BUILD_DIR) $(DIST_DIR) $(TEST_FILE)
 
-#-include $(DEP_FILES)
+-include $(DEP_FILES)

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ $(BUILD_DIR)/%_arm64.o: %.cpp $(IMPORTED)
 	$(CXX) -c $(CFLAGS) -arch arm64 -I src/decomp/include -o $@ $<
 
 $(LIB_FILE): $(OBJS_x86_64) $(OBJS_arm64)
-	$(CC) $(LDFLAGS) -arch arm64 -o arm64$@ $(OBJS_arm64)
-	$(CC) $(LDFLAGS) -arch arm64 -o x86_64$@ $(OBJS_x86_64)
+	$(CC) $(LDFLAGS) -arch arm64 -o $@.arm64 $(OBJS_arm64)
+	$(CC) $(LDFLAGS) -arch arm64 -o $@.x86_64 $(OBJS_x86_64)
 	lipo -create -output $@ arm64$@ x86_64$@
 
 else

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,6 @@ else
   LDFLAGS := -lm -shared
 endif
 CFLAGS := -fno-strict-aliasing -g -Wall -Wno-unused-function -fPIC -fvisibility=hidden -DSM64_LIB_EXPORT -DGBI_FLOATS -DVERSION_US -DNO_SEGMENTED_MEMORY
-ifeq ($(shell uname -s),Darwin)
-  CFLAGS += -arch x86_64 -arch arm64
-  LDFLAGS = -arch x86_64 -arch arm64
-endif
 
 SRC_DIRS  := src src/decomp src/decomp/engine src/decomp/include/PR src/decomp/game src/decomp/pc src/decomp/pc/audio src/decomp/mario src/decomp/tools src/decomp/audio
 BUILD_DIR := build

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ else
 endif
 CFLAGS := -fno-strict-aliasing -g -Wall -Wno-unused-function -fPIC -fvisibility=hidden -DSM64_LIB_EXPORT -DGBI_FLOATS -DVERSION_US -DNO_SEGMENTED_MEMORY
 ifeq ($(shell uname -s),Darwin)
-  CFLAGS += -arch x86_64 -arch arm64
   LDFLAGS += -arch x86_64 -arch arm64
 endif
 
@@ -49,11 +48,21 @@ src/decomp/mario/geo.inc.c: ./import-mario-geo.py
 	./import-mario-geo.py
 
 $(BUILD_DIR)/%.o: %.c $(IMPORTED)
-	@$(CC) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
+	ifeq ($(shell uname -s),Darwin)
+		@$(CC) $(CFLAGS) -arch arm64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_arm64.d $<
+		@$(CC) $(CFLAGS) -arch x86_64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_x86_64.d $<
+	else
+		@$(CC) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
+	endif
 	$(CC) -c $(CFLAGS) -I src/decomp/include -o $@ $<
 
 $(BUILD_DIR)/%.o: %.cpp $(IMPORTED)
-	@$(CXX) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
+	ifeq ($(shell uname -s),Darwin)
+		@$(CXX) $(CFLAGS) -arch arm64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_arm64.d $<
+		@$(CXX) $(CFLAGS) -arch x86_64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_x86_64.d $<
+	else
+		@$(CXX) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
+	endif
 	$(CXX) -c $(CFLAGS) -I src/decomp/include -o $@ $<
 
 $(LIB_FILE): $(O_FILES)

--- a/Makefile
+++ b/Makefile
@@ -66,14 +66,6 @@ $(BUILD_DIR)/%_arm64.o: %.c $(IMPORTED)
 	@$(CC) $(CFLAGS) -arch arm64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_arm64.d $<
 	$(CC) -c $(CFLAGS) -arch arm64 -I src/decomp/include -o $@ $<
 
-$(BUILD_DIR)/%_x86_64.o: %.cpp $(IMPORTED)
-	@$(CXX) $(CFLAGS) -arch x86_64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_x86_64.d $<
-	$(CXX) -c $(CFLAGS) -arch x86_64 -I src/decomp/include -o $@ $<
-
-$(BUILD_DIR)/%_arm64.o: %.cpp $(IMPORTED)
-	@$(CXX) $(CFLAGS) -arch arm64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_arm64.d $<
-	$(CXX) -c $(CFLAGS) -arch arm64 -I src/decomp/include -o $@ $<
-
 $(LIB_FILE): $(O_FILES_x86_64) $(O_FILES_arm64)
 	$(CC) $(LDFLAGS) -arch arm64 -o $@.arm64 $(O_FILES_arm64)
 	$(CC) $(LDFLAGS) -arch x86_64 -o $@.x86_64 $(O_FILES_x86_64)
@@ -83,10 +75,6 @@ else
 $(BUILD_DIR)/%.o: %.c $(IMPORTED)
 	@$(CC) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
 	$(CC) -c $(CFLAGS) -I src/decomp/include -o $@ $<
-
-$(BUILD_DIR)/%.o: %.cpp $(IMPORTED)
-	@$(CXX) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
-	$(CXX) -c $(CFLAGS) -I src/decomp/include -o $@ $<
 
 $(LIB_FILE): $(O_FILES)
 	$(CC) $(LDFLAGS) -o $@ $^
@@ -103,6 +91,10 @@ test/main.cpp test/gl20/gl20_renderer.c test/gl33core/gl33core_renderer.c: test/
 $(BUILD_DIR)/test/%.o: test/%.c
 	@$(CC) $(CFLAGS) -MM -MP -MT $@ -MF $(BUILD_DIR)/test/$*.d $<
 	$(CC) -c $(CFLAGS) -o $@ $<
+
+$(BUILD_DIR)/test/%.o: test/%.cpp
+	@$(CXX) $(CFLAGS) -MM -MP -MT $@ -MF $(BUILD_DIR)/test/$*.d $<
+	$(CXX) -c $(CFLAGS) -o $@ $<
 
 $(TEST_FILE): $(LIB_FILE) $(TEST_OBJS)
 ifdef WINDOWS_BUILD

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,14 @@ $(BUILD_DIR)/%_arm64.o: %.c $(IMPORTED)
 	@$(CC) $(CFLAGS) -arch arm64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_arm64.d $<
 	$(CC) -c $(CFLAGS) -arch arm64 -I src/decomp/include -o $@ $<
 
+$(BUILD_DIR)/%_x86_64.o: %.cpp $(IMPORTED)
+	@$(CC) $(CFLAGS) -arch x86_64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_x86_64.d $<
+	$(CC) -c $(CFLAGS) -arch x86_64 -I src/decomp/include -o $@ $<
+
+$(BUILD_DIR)/%_arm64.o: %.cpp $(IMPORTED)
+	@$(CXX) $(CFLAGS) -arch arm64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_arm64.d $<
+	$(CXX) -c $(CFLAGS) -arch arm64 -I src/decomp/include -o $@ $<
+
 $(LIB_FILE): $(OBJS_x86_64) $(OBJS_arm64)
 	$(CC) $(LDFLAGS) -arch arm64 -o arm64$@ $(OBJS_arm64)
 	$(CC) $(LDFLAGS) -arch arm64 -o x86_64$@ $(OBJS_x86_64)

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ $(BUILD_DIR)/%_arm64.o: %.cpp $(IMPORTED)
 $(LIB_FILE): $(OBJS_x86_64) $(OBJS_arm64)
 	$(CC) $(LDFLAGS) -arch arm64 -o $@.arm64 $(OBJS_arm64)
 	$(CC) $(LDFLAGS) -arch x86_64 -o $@.x86_64 $(OBJS_x86_64)
-	lipo -create -output $@ arm64$@ x86_64$@
+	lipo -create -output $@ $@.arm64 $@.x86_64
 
 else
 

--- a/Makefile
+++ b/Makefile
@@ -58,19 +58,19 @@ src/decomp/mario/geo.inc.c: ./import-mario-geo.py
 
 ifeq ($(shell uname -s),Darwin)
 $(BUILD_DIR)/%_x86_64.o: %.c $(IMPORTED)
-	@$(CC) $(CFLAGS) -arch x86_64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_x86_64.d $<
+#	@$(CC) $(CFLAGS) -arch x86_64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_x86_64.d $<
 	$(CC) -c $(CFLAGS) -arch x86_64 -I src/decomp/include -o $@ $<
 
 $(BUILD_DIR)/%_arm64.o: %.c $(IMPORTED)
-	@$(CC) $(CFLAGS) -arch arm64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_arm64.d $<
+#	@$(CC) $(CFLAGS) -arch arm64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_arm64.d $<
 	$(CC) -c $(CFLAGS) -arch arm64 -I src/decomp/include -o $@ $<
 
 $(BUILD_DIR)/%_x86_64.o: %.cpp $(IMPORTED)
-	@$(CC) $(CFLAGS) -arch x86_64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_x86_64.d $<
+#	@$(CC) $(CFLAGS) -arch x86_64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_x86_64.d $<
 	$(CC) -c $(CFLAGS) -arch x86_64 -I src/decomp/include -o $@ $<
 
 $(BUILD_DIR)/%_arm64.o: %.cpp $(IMPORTED)
-	@$(CXX) $(CFLAGS) -arch arm64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_arm64.d $<
+#	@$(CXX) $(CFLAGS) -arch arm64 -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*_arm64.d $<
 	$(CXX) -c $(CFLAGS) -arch arm64 -I src/decomp/include -o $@ $<
 
 $(LIB_FILE): $(OBJS_x86_64) $(OBJS_arm64)
@@ -81,11 +81,11 @@ $(LIB_FILE): $(OBJS_x86_64) $(OBJS_arm64)
 else
 
 $(BUILD_DIR)/%.o: %.c $(IMPORTED)
-	@$(CC) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
+#	@$(CC) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
 	$(CC) -c $(CFLAGS) -I src/decomp/include -o $@ $<
 
 $(BUILD_DIR)/%.o: %.cpp $(IMPORTED)
-	@$(CXX) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
+#	@$(CXX) $(CFLAGS) -I src/decomp/include -MM -MP -MT $@ -MF $(BUILD_DIR)/$*.d $<
 	$(CXX) -c $(CFLAGS) -I src/decomp/include -o $@ $<
 
 $(LIB_FILE): $(O_FILES)
@@ -127,4 +127,4 @@ endif
 clean:
 	rm -rf $(BUILD_DIR) $(DIST_DIR) $(TEST_FILE)
 
--include $(DEP_FILES)
+#-include $(DEP_FILES)


### PR DESCRIPTION
Change the Makefile in order to generate universal binaries on macOS. Also change the file extension to the more standard ".dylib".