### PR TITLE
Exposed forwardVelocity, animID, and animFrame in outState.

### DIFF
--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -15,6 +15,7 @@
 #include "decomp/engine/math_util.h"
 #include "decomp/include/sm64.h"
 #include "decomp/include/seq_ids.h"
+#include "decomp/include/types.h"
 #include "decomp/shim.h"
 #include "decomp/memory.h"
 #include "decomp/global_state.h"
@@ -255,7 +256,13 @@ SM64_LIB_FN void sm64_mario_tick( int32_t marioId, const struct SM64MarioInputs 
     vec3f_copy( outState->position, gMarioState->pos );
     vec3f_copy( outState->velocity, gMarioState->vel );
     outState->faceAngle = (float)gMarioState->faceAngle[1] / 32768.0f * 3.14159f;
+    outState->forwardVelocity = gMarioState->forwardVel;
     outState->action = gMarioState->action;
+
+    struct AnimInfo animInfo = gMarioState->marioObj->header.gfx.animInfo;
+    outState->animID = animInfo.animID;
+    outState->animID = animInfo.animFrame;
+
     outState->flags = gMarioState->flags;
     outState->particleFlags = gMarioState->particleFlags;
     outState->invincTimer = gMarioState->invincTimer;

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -58,8 +58,11 @@ struct SM64MarioState
     float position[3];
     float velocity[3];
     float faceAngle;
+    float forwardVelocity;
     int16_t health;
     uint32_t action;
+    int32_t animID;
+    int16_t animFrame;
     uint32_t flags;
     uint32_t particleFlags;
     int16_t invincTimer;


### PR DESCRIPTION
Hello! It's been a while since my last pull request, but I set up a tiny change to add some fields to outState so they're possible to query in tick events. These ones are already settable, they're just not gettable until this PR.