### PR TITLE
Implemented handling for Poles.

### DIFF
--- a/src/libsm64.c
+++ b/src/libsm64.c
@@ -37,6 +37,7 @@
 #include "load_tex_data.h"
 #include "obj_pool.h"
 #include "fake_interaction.h"
+#include "pole.h"
 
 static struct AllocOnlyPool *s_mario_geo_pool = NULL;
 static struct GraphNode *s_mario_graph_node = NULL;
@@ -109,6 +110,7 @@ SM64_LIB_FN void sm64_global_init( const uint8_t *rom, uint8_t *outTexture )
     load_mario_anims_from_rom( rom );
 
     memory_init();
+    pole_pool_init();
 }
 
 SM64_LIB_FN void sm64_global_terminate( void )
@@ -724,4 +726,56 @@ SM64_LIB_FN void sm64_play_sound_global(int32_t soundBits)
 SM64_LIB_FN void sm64_set_sound_volume(float vol)
 {
     gAudioVolume = vol;
+}
+
+SM64_LIB_FN int32_t sm64_pole_create(float x, float y, float z, float height, float downOffset, int16_t pitch, int16_t roll)
+{
+    return pole_pool_create(x, y, z, height, downOffset, pitch, roll);
+}
+ 
+SM64_LIB_FN void sm64_pole_destroy(int32_t poleHandle)
+{
+    struct Object *dying = pole_pool_get(poleHandle);
+    if (dying == NULL) {
+        return;
+    }
+ 
+    for (int i = 0; i < s_mario_instance_pool.size; ++i)
+    {
+        if (s_mario_instance_pool.objects[i] == NULL)
+            continue;
+ 
+        struct GlobalState *globalState = ((struct MarioInstance *)s_mario_instance_pool.objects[i])->globalState;
+        global_state_bind(globalState);
+ 
+        if (gMarioState->usedObj == dying)
+        {
+            gMarioState->usedObj = NULL;
+            set_mario_action(gMarioState, ACT_FREEFALL, 0);
+        }
+    }
+ 
+    pole_pool_release(poleHandle);
+}
+ 
+SM64_LIB_FN void sm64_mario_attach_to_pole(int32_t marioId, int32_t poleHandle, int32_t grabFast)
+{
+    if( marioId >= s_mario_instance_pool.size || s_mario_instance_pool.objects[marioId] == NULL )
+    {
+        DEBUG_PRINT("Tried to use non-existant Mario with ID: %d", marioId);
+        return;
+    }
+ 
+    struct Object *pole = pole_pool_get(poleHandle);
+    if (pole == NULL)
+    {
+        DEBUG_PRINT("Tried to attach Mario to non-existant pole handle: %d", poleHandle);
+        return;
+    }
+ 
+    struct GlobalState *globalState = ((struct MarioInstance *)s_mario_instance_pool.objects[ marioId ])->globalState;
+    global_state_bind( globalState );
+ 
+    gMarioState->usedObj = pole;
+    set_mario_action(gMarioState, grabFast ? ACT_GRAB_POLE_FAST : ACT_GRAB_POLE_SLOW, 0);
 }

--- a/src/libsm64.h
+++ b/src/libsm64.h
@@ -202,6 +202,11 @@ extern SM64_LIB_FN void sm64_play_sound(int32_t soundBits, float *pos);
 extern SM64_LIB_FN void sm64_play_sound_global(int32_t soundBits);
 extern SM64_LIB_FN void sm64_set_sound_volume(float vol);
 
+extern SM64_LIB_FN int32_t sm64_pole_create(float x, float y, float z, float height, float downOffset, int16_t pitch, int16_t roll);
+extern SM64_LIB_FN void sm64_pole_destroy(int32_t poleHandle);
+extern SM64_LIB_FN void sm64_mario_attach_to_pole(int32_t marioId, int32_t poleHandle, int32_t grabFast);
+extern SM64_LIB_FN int32_t sm64_mario_get_action(int32_t marioId);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/pole.c
+++ b/src/pole.c
@@ -1,0 +1,48 @@
+#include <string.h>
+#include "pole.h"
+#include "decomp/include/object_fields.h"
+
+static struct Object sPolePool[MAX_POLE_OBJECTS];
+static u8            sPoleInUse[MAX_POLE_OBJECTS];
+
+void pole_pool_init(void) {
+    memset(sPolePool, 0, sizeof(sPolePool));
+    memset(sPoleInUse, 0, sizeof(sPoleInUse));
+}
+
+s32 pole_pool_create(f32 x, f32 y, f32 z, f32 height, f32 downOffset, s16 pitch, s16 roll) {
+    for (s32 i = 0; i < MAX_POLE_OBJECTS; i++) {
+        if (!sPoleInUse[i]) {
+            struct Object *o = &sPolePool[i];
+            memset(o, 0, sizeof(struct Object));
+
+            o->oPosX = x;
+            o->oPosY = y;
+            o->oPosZ = z;
+            o->oMoveAnglePitch = pitch;
+            o->oMoveAngleRoll  = roll;
+
+            o->hitboxHeight     = height;
+            o->hitboxDownOffset = downOffset;
+            o->behavior = NULL;
+
+            sPoleInUse[i] = 1;
+            return i;
+        }
+    }
+    return -1;
+}
+
+void pole_pool_release(s32 handle) {
+    if (handle < 0 || handle >= MAX_POLE_OBJECTS || !sPoleInUse[handle]) {
+        return;
+    }
+    sPoleInUse[handle] = 0;
+}
+
+struct Object *pole_pool_get(s32 handle) {
+    if (handle < 0 || handle >= MAX_POLE_OBJECTS || !sPoleInUse[handle]) {
+        return NULL;
+    }
+    return &sPolePool[handle];
+}

--- a/src/pole.h
+++ b/src/pole.h
@@ -1,0 +1,16 @@
+#ifndef POLE_H
+#define POLE_H
+
+#include "decomp/include/types.h"
+
+#define MAX_POLE_OBJECTS 128
+
+void pole_pool_init(void);
+
+s32 pole_pool_create(f32 x, f32 y, f32 z, f32 height, f32 downOffset, s16 pitch, s16 roll);
+
+void pole_pool_release(s32 handle);
+
+struct Object *pole_pool_get(s32 handle);
+
+#endif // POLE_H


### PR DESCRIPTION
I was messing around with inifinite mario 64 and wanted to implement trees.

That needed the ability for them to be climbed which wasn't supported out of the box.

Here is an implementation of exactly that.
Create a pole, mario can attach to the pole, climb it and handstand at the top.

Functions exactly as it does in normal SM64.